### PR TITLE
Fix cloning done by sklearn

### DIFF
--- a/molfeat/trans/fp.py
+++ b/molfeat/trans/fp.py
@@ -93,7 +93,7 @@ class FPVecTransformer(MoleculeTransformer):
 
     def __len__(self):
         """Compute featurizer length"""
-        if self._length is not None:
+        if getattr(self, "cols_to_keep", None) is None and self._length is not None:
             return self._length
         return super().__len__()
 


### PR DESCRIPTION
Checklist:

- [ ] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
- [ ] Update the API documentation is a new function is added or an existing one is deleted.
- [ ] Added a `news` entry.
  - _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---

The following should now work (a bit of ranting in the comments)

```python
import datamol as dm
from molfeat.trans.fp import FPVecTransformer
from sklearn.ensemble import RandomForestRegressor
from sklearn.preprocessing import StandardScaler
from sklearn.model_selection import train_test_split
from sklearn.pipeline import Pipeline
from sklearn.model_selection import GridSearchCV

df = dm.data.freesolv()
X, y = df["smiles"], df["expt"]
X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)

# To search over the featurizer, we use a single transformer that combines several calculators.
feat = FPVecTransformer(kind="rdkit")

param_grid = dict(
    feat__kind=["fcfp:6", "ecfp:6", "maccs"],
    feat__length=[512, 1024],
    rf__n_estimators=[100, 500],
)

pipe = Pipeline([("feat", feat), ("scaler", StandardScaler()), ("rf", RandomForestRegressor(n_estimators=100))])
grid_search = GridSearchCV(pipe, param_grid=param_grid, n_jobs=-1)

with dm.without_rdkit_log():
    grid_search.fit(X_train, y_train)
    score = grid_search.score(X_test, y_test)

score
````
ping @cwognum 