### PR TITLE
chore: delete redundant `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-# for the documentation and syntax
-
-* @maclandrol


### PR DESCRIPTION
This PR aims to delete the redundant `CODEOWNERS` file from the root. There already exists a duplicate file within the `.github/` directory.