### PR TITLE
Fixes issue #26 by checking if the np.float128 dtype exists

### DIFF
--- a/molfeat/trans/base.py
+++ b/molfeat/trans/base.py
@@ -11,6 +11,7 @@ import abc
 import copy
 import joblib
 import json
+
 import yaml
 import fsspec
 import pandas as pd
@@ -33,13 +34,11 @@ from molfeat.utils.commons import fn_to_hex
 from molfeat.utils.commons import hex_to_fn
 from molfeat.utils.parsing import get_input_args
 from molfeat.utils.parsing import import_from_string
-from molfeat.utils.state import DTYPES_MAPPING
-from molfeat.utils.state import DTYPES_MAPPING_REVERSE
+from molfeat.utils.state import map_dtype
 from molfeat.utils.state import ATOM_FEATURIZER_MAPPING
 from molfeat.utils.state import BOND_FEATURIZER_MAPPING
 from molfeat.utils.state import ATOM_FEATURIZER_MAPPING_REVERSE
 from molfeat.utils.state import BOND_FEATURIZER_MAPPING_REVERSE
-from molfeat.utils.state import get_type_mapping
 
 _TRANSFORMERS = {}
 
@@ -514,13 +513,9 @@ class MoleculeTransformer(TransformerMixin, BaseFeaturizer, metaclass=_Transform
         # Process the input arguments before building the state
         args = copy.deepcopy(self._input_args)
 
-        ## Deal with dtype
+        # Deal with dtype
         if "dtype" in args and not isinstance(args["dtype"], str):
-            if args["dtype"] not in DTYPES_MAPPING:
-                raise ValueError(
-                    f"Invalid dtype {args['dtype']}. Valid dtypes are {DTYPES_MAPPING.keys()}"
-                )
-            args["dtype"] = DTYPES_MAPPING[args["dtype"]]
+            args["dtype"] = map_dtype(args["dtype"])
 
         ## Deal with graph atom/bond featurizers
         # NOTE(hadim): it's important to highlight that atom/bond featurizers can't be
@@ -609,14 +604,9 @@ class MoleculeTransformer(TransformerMixin, BaseFeaturizer, metaclass=_Transform
         # Process the state as needed
         args = state.get("args", {})
 
-        ## Deal with dtype
-        if "dtype" in args:
-            if args["dtype"] not in DTYPES_MAPPING_REVERSE:
-                raise ValueError(
-                    f"Invalid dtype {args['dtype']}. Valid dtypes are"
-                    f" {DTYPES_MAPPING_REVERSE.keys()}"
-                )
-            args["dtype"] = DTYPES_MAPPING_REVERSE[args["dtype"]]
+        # Deal with dtype
+        if "dtype" in args and isinstance(args["dtype"], str):
+            args["dtype"] = map_dtype(args["dtype"])
 
         ## Deal with graph atom/bond featurizers
         if args.get("atom_featurizer") is not None:

--- a/molfeat/utils/state.py
+++ b/molfeat/utils/state.py
@@ -40,10 +40,6 @@ DTYPES_MAPPING = {
     float: "float",
 }
 
-# Since np.float128 is not supported on all systems, we first check if it's available
-if hasattr(np, "float128"):
-    DTYPES_MAPPING[np.float128] = "np.float128"
-
 DTYPES_MAPPING_REVERSE = {v: k for k, v in DTYPES_MAPPING.items()}
 
 ATOM_FEATURIZER_MAPPING = {
@@ -68,21 +64,13 @@ BOND_FEATURIZER_MAPPING_REVERSE = {v: k for k, v in BOND_FEATURIZER_MAPPING.item
 def map_dtype(dtype: Optional[Union[str, torch.dtype, np.dtype]]):
     """Map a dtype to a string representation or the other way around"""
 
-    # np.float128 is not available on all systems so mapping from a string to this dtype can fail.
-    # Since this is an exceptional case, we specifically check for it to raise a more informative error
-    is_np128 = dtype == "np.float128"
-
     if isinstance(dtype, str):
         mapping = DTYPES_MAPPING_REVERSE
     else:
         mapping = DTYPES_MAPPING
 
     if dtype not in mapping:
-        if is_np128:
-            msg = f"{dtype} is not supported on your system. "
-        else:
-            msg = f"{dtype} is not a valid dtype. "
-        msg += f"Valid dtypes are {list(mapping.keys())}"
+        msg = f"{dtype} is not a valid dtype. The valid dtypes are {list(mapping.keys())}."
         raise ValueError(msg)
 
     return mapping[dtype]

--- a/news/fix-26.rst
+++ b/news/fix-26.rst
@@ -12,11 +12,11 @@
 
 **Removed:**
 
-* <news item>
+* Remove support for the `np.float128` dtype (issue #26)
 
 **Fixed:**
 
-* Since the np.float128 dtype is not available on all system, we now first check if it exists (issue #26)
+* <news item>
 
 **Security:**
 

--- a/news/fix-26.rst
+++ b/news/fix-26.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Since the np.float128 dtype is not available on all system, we now first check if it exists (issue #26)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Checklist:

- [ ] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
- [ ] Update the API documentation if a new function is added or an existing one is deleted.
- [X] Added a `news` entry.
  - _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---

Fixes #26 

We now check if the `np.float128` dtype exists in the `numpy` module. Because this to me felt like a special case, I wanted it to throw a more specific warning on loading the dtype. To avoid code duplication, I wrapped this in a new function.

I haven't been able to test this as the `np.float128` is available on my system, but I was wondering if we could add another system to our testing matrix that lacks it? 