### PR TITLE
chore/: Remove Mordred support

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -30,7 +30,6 @@ dependencies:
   - datamol >=0.8.0
   - rdkit >=2021.09
   - pmapper
-  - mordred
 
   # ML
   - pytorch =1.12

--- a/molfeat/calc/__init__.py
+++ b/molfeat/calc/__init__.py
@@ -1,14 +1,10 @@
-from .base import SerializableCalculator
-from .base import _CALCULATORS
+from .base import SerializableCalculator, _CALCULATORS
 from .cats import CATS
-from .descriptors import RDKitDescriptors2D
-from .descriptors import RDKitDescriptors3D
-from .descriptors import MordredDescriptors
+from .descriptors import RDKitDescriptors2D, RDKitDescriptors3D
 from .fingerprints import FPCalculator, FP_FUNCS
-from .pharmacophore import Pharmacophore2D
-from .pharmacophore import Pharmacophore3D
+from .pharmacophore import Pharmacophore2D, Pharmacophore3D
+from .shape import ElectroShapeDescriptors, USRDescriptors
 from .skeys import ScaffoldKeyCalculator
-from .shape import USRDescriptors, ElectroShapeDescriptors
 
 
 def get_calculator(name: str, **params):
@@ -35,8 +31,6 @@ def get_calculator(name: str, **params):
         featurizer = RDKitDescriptors3D(**params)
     elif name == "desc2d":
         featurizer = RDKitDescriptors2D(**params)
-    elif name == "mordred":
-        featurizer = MordredDescriptors(**params)
     elif name == "cats":
         featurizer = CATS(**params)
     elif name == "cats2d":

--- a/molfeat/calc/descriptors.py
+++ b/molfeat/calc/descriptors.py
@@ -1,30 +1,16 @@
 import copy
-from typing import Union, List, Optional
 from collections import OrderedDict
+from typing import List, Optional, Union
 
 import datamol as dm
 import numpy as np
-
 from loguru import logger
+from rdkit.Chem import Descriptors, Descriptors3D, FindMolChiralCenters, rdMolDescriptors, rdPartialCharges
 from rdkit.Chem.QED import properties
-from rdkit.Chem import Descriptors
-from rdkit.Chem import Descriptors3D
-from rdkit.Chem import FindMolChiralCenters
-from rdkit.Chem import rdPartialCharges
-from rdkit.Chem import rdMolDescriptors
 
-from molfeat.utils.commons import requires_conformer
-from molfeat.utils.commons import requires_standardization
-from molfeat.utils.datatype import to_numpy
-from molfeat.utils import requires
 from molfeat.calc.base import SerializableCalculator
-
-if requires.check("mordred"):
-    from mordred import Calculator as MordredCalculator
-    from mordred import descriptors as mordred_descriptors
-
-else:
-    MordredCalculator = requires.mock("mordred")
+from molfeat.utils.commons import requires_conformer, requires_standardization
+from molfeat.utils.datatype import to_numpy
 
 
 def _charge_descriptors_computation(mol: dm.Mol):
@@ -179,90 +165,6 @@ class RDKitDescriptors2D(SerializableCalculator):
         return vals
 
 
-class MordredDescriptors(SerializableCalculator):
-    r"""
-    Compute mordred descriptors.
-    The descriptor calculator does not mask errors in featurization and will propagate them.
-
-    !!! note
-        Mordred descriptors can results in undefined or nan behaviour depending on your input molecule.
-        It is recommended that the user handles those nan values himself by either removing the descriptor
-        or imputing the missing values.
-    """
-
-    def __init__(
-        self,
-        ignore_3D: bool = True,
-        replace_nan: bool = False,
-        do_not_standardize: bool = False,
-        **kwargs,
-    ):
-        """Mordred descriptor computation
-
-        Args:
-            ignore_3D (bool, optional): Whether to ignore 3D descriptors or include them
-            replace_nan (bool, optional): Whether to replace nan or infinite values. Defaults to False.
-            do_not_standardize: Whether to force standardize molecules or keep it the same
-
-        """
-        if not requires.check("mordred"):
-            logger.error(
-                "`mordred` is not available, please install it `pip install 'mordred[full]'`"
-            )
-            raise ImportError("Cannot import `mordred`")
-        self.replace_nan = replace_nan
-        self.ignore_3D = ignore_3D
-        self.do_not_standardize = do_not_standardize
-        self._calc = None
-        self._init_calc()
-
-    def _init_calc(self):
-        """Initialize mordred calculator"""
-        self._calc = MordredCalculator(mordred_descriptors, ignore_3D=self.ignore_3D)
-
-    @property
-    def columns(self):
-        """
-        Get the name of all the descriptors of this calculator
-        """
-        return [str(x) for x in self._calc.descriptors]
-
-    def __len__(self):
-        """Return the length of the calculator"""
-        return len(self._calc)
-
-    def __getstate__(self):
-        """Serialize the class for pickling."""
-        state = {}
-        state["ignore_3D"] = self.ignore_3D
-        state["replace_nan"] = self.replace_nan
-        state["do_not_standardize"] = getattr(self, "do_not_standardize", False)
-        return state
-
-    def __setstate__(self, state: dict):
-        """Reload the class from pickling."""
-        self.__dict__.update(state)
-        self._init_calc()
-
-    def __call__(self, mol: Union[dm.Mol, str], conformer_id: Optional[int] = -1):
-        r"""
-        Get rdkit basic descriptors for a molecule
-
-        Args:
-            mol: the molecule of interest
-            conformer_id (int, optional): Optional
-
-        Returns:
-            props (np.ndarray): list of computed mordred molecular descriptors
-        """
-        mol = dm.to_mol(mol)
-        vals = self._calc(mol, conformer_id).fill_missing()
-        vals = to_numpy(vals)
-        if self.replace_nan:
-            vals = np.nan_to_num(vals)
-        return vals
-
-
 class RDKitDescriptors3D(SerializableCalculator):
     """
     Compute a list of 3D rdkit descriptors
@@ -330,16 +232,16 @@ class RDKitDescriptors3D(SerializableCalculator):
         return self._columns
 
     @requires_conformer
-    def __call__(self, mol: Union[dm.Mol, str], conformer_id: Optional[int] = -1):
+    def __call__(self, mol: Union[dm.Mol, str], conformer_id: Optional[int] = -1) -> np.ndarray:
         r"""
         Get rdkit 3D descriptors for a molecule
 
         Args:
             mol: the molecule of interest
-            conformer_id (int, optional): Optional conformer id. Defaults to -1.
+            conformer_id: Optional conformer id. Defaults to -1.
 
         Returns:
-            props (np.ndarray): list of computed mordred molecular descriptors
+            props: list of computed molecular descriptors
         """
 
         mol = dm.to_mol(mol)

--- a/molfeat/calc/descriptors.py
+++ b/molfeat/calc/descriptors.py
@@ -5,7 +5,13 @@ from typing import List, Optional, Union
 import datamol as dm
 import numpy as np
 from loguru import logger
-from rdkit.Chem import Descriptors, Descriptors3D, FindMolChiralCenters, rdMolDescriptors, rdPartialCharges
+from rdkit.Chem import (
+    Descriptors,
+    Descriptors3D,
+    FindMolChiralCenters,
+    rdMolDescriptors,
+    rdPartialCharges,
+)
 from rdkit.Chem.QED import properties
 
 from molfeat.calc.base import SerializableCalculator

--- a/molfeat/calc/shape.py
+++ b/molfeat/calc/shape.py
@@ -1,13 +1,11 @@
-from typing import Union, List, Optional
+from typing import List, Optional, Union
 
 import datamol as dm
 import numpy as np
-
-from loguru import logger
 from numpy.linalg import norm
+from rdkit.Chem import rdForceFieldHelpers, rdMolDescriptors, rdPartialCharges
 from scipy.special import cbrt
-from rdkit.Chem import rdPartialCharges, rdForceFieldHelpers
-from rdkit.Chem import rdMolDescriptors
+
 from molfeat.calc.base import SerializableCalculator
 from molfeat.utils.commons import requires_conformer
 
@@ -58,16 +56,16 @@ class USRDescriptors(SerializableCalculator):
         return len(self.columns)
 
     @requires_conformer
-    def __call__(self, mol: Union[dm.Mol, str], conformer_id: Optional[int] = -1):
+    def __call__(self, mol: Union[dm.Mol, str], conformer_id: Optional[int] = -1) -> np.ndarray:
         r"""
         Get rdkit 3D descriptors for a molecule
 
         Args:
             mol: the molecule of interest
-            conformer_id (int, optional): Optional conformer id. Defaults to -1.
+            conformer_id: Optional conformer id. Defaults to -1.
 
         Returns:
-            shape_descriptors (np.ndarray): list of computed mordred molecular descriptors
+            shape_descriptors: list of computed molecular descriptors
         """
         if self.method == "USR":
             shape_descr = rdMolDescriptors.GetUSR(mol, confId=conformer_id)

--- a/molfeat/trans/fp.py
+++ b/molfeat/trans/fp.py
@@ -32,7 +32,6 @@ class FPVecTransformer(MoleculeTransformer):
     AVAILABLE_FPS = list(FP_FUNCS.keys()) + [
         "desc3D",
         "desc2D",
-        "mordred",
         "cats2D",
         "cats3D",
         "pharm2D",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
     "scikit-learn",
     "packaging",
     "pmapper",
-    "mordred",
 
 ]
 
@@ -126,7 +125,6 @@ minversion = "6.0"
 addopts = "--verbose --cov-report xml --cov-report term --color yes"
 testpaths = ["tests"]
 norecursedirs = "tests/helpers"
-filterwarnings = ["ignore::DeprecationWarning:mordred.*:"]
 
 [tool.coverage.run]
 omit = ["setup.py", "tests/*"]

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -12,7 +12,7 @@ from molfeat.calc import (
     RDKitDescriptors2D,
     RDKitDescriptors3D,
     ScaffoldKeyCalculator,
-    USRDescriptors
+    USRDescriptors,
 )
 from molfeat.calc.skeys import skdistance
 

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -1,22 +1,20 @@
-import unittest as ut
-import pytest
-
 import tempfile
-
-import joblib
+import unittest as ut
 
 import datamol as dm
+import joblib
 import numpy as np
+import pytest
 
-from molfeat.calc import CATS
-from molfeat.calc import ScaffoldKeyCalculator
-from molfeat.calc import RDKitDescriptors2D
-from molfeat.calc import RDKitDescriptors3D
-from molfeat.calc import MordredDescriptors
-from molfeat.calc import USRDescriptors
-from molfeat.calc import ElectroShapeDescriptors
+from molfeat.calc import (
+    CATS,
+    ElectroShapeDescriptors,
+    RDKitDescriptors2D,
+    RDKitDescriptors3D,
+    ScaffoldKeyCalculator,
+    USRDescriptors
+)
 from molfeat.calc.skeys import skdistance
-from molfeat.utils import requires
 
 
 class TestDescPharm(ut.TestCase):
@@ -60,12 +58,6 @@ class TestDescPharm(ut.TestCase):
         calc = RDKitDescriptors3D()
         mol = dm.conformers.generate(dm.to_mol(self.smiles[0]))
         fps = calc(mol)
-        self.assertEqual(len(fps), len(calc))
-
-    @pytest.mark.xfail(not requires.check("mordred"), reason="3rd party module mordred is missing")
-    def test_mordred(self):
-        calc = MordredDescriptors()
-        fps = calc(self.smiles[0])
         self.assertEqual(len(fps), len(calc))
 
     def test_cats_2d(self):

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -1,24 +1,23 @@
-import time
 import os
 import shutil
-import unittest as ut
-import torch
-import datamol as dm
-import pandas as pd
-import numpy as np
 import tempfile
-import joblib
+import time
+import unittest as ut
 
+import datamol as dm
+import joblib
+import numpy as np
+import pandas as pd
+import torch
 from rdkit.DataStructs.cDataStructs import ExplicitBitVect
-from molfeat.calc import SerializableCalculator
-from molfeat.calc.descriptors import MordredDescriptors
+
+from molfeat.calc import RDKitDescriptors2D, SerializableCalculator
 from molfeat.calc.fingerprints import FPCalculator
 from molfeat.calc.pharmacophore import Pharmacophore2D
 from molfeat.trans import MoleculeTransformer
 from molfeat.trans.base import PrecomputedMolTransformer
-from molfeat.trans.fp import FPVecTransformer
-from molfeat.trans.fp import FPVecFilteredTransformer
 from molfeat.trans.concat import FeatConcat
+from molfeat.trans.fp import FPVecFilteredTransformer, FPVecTransformer
 from molfeat.utils.cache import DataCache, FileCache, MPDataCache
 
 
@@ -231,13 +230,12 @@ class TestMolTransformer(ut.TestCase):
         out2, ids = concat_transf1(self.smiles, enforce_dtype=True, ignore_errors=True)
         np.testing.assert_allclose(out1, out2)
 
-    # @pytest.mark.xfail
     def test_caching(self):
-        ## check performance when cache is added from existing cache
+        # check performance when cache is added from existing cache
         smiles = dm.data.freesolv().smiles.values[:50]
-        desc = MordredDescriptors(replace_nan=False, ignore_3D=True)
+        desc = RDKitDescriptors2D(replace_nan=False, ignore_3D=True)
         transff = MoleculeTransformer(desc, verbose=True)
-        cache = DataCache(name="mordred")
+        cache = DataCache(name="rdkit2d")
 
         t1 = time.time()
         out1 = transff(smiles)
@@ -264,7 +262,7 @@ class TestMolTransformer(ut.TestCase):
         self.assertTrue(elapsed3 <= elapsed1 or elapsed1 < 1.5)
         np.testing.assert_array_equal(out1, out3)
 
-        ## check when cache is build on the fly from a
+        # check when cache is build on the fly from a
         transff = MoleculeTransformer("desc2d")
         cache = DataCache(name="desc2d_transformer1")
         t1 = time.time()
@@ -280,7 +278,7 @@ class TestMolTransformer(ut.TestCase):
         np.testing.assert_array_equal(out1, out2)
         np.testing.assert_array_equal(out1, out3)
 
-        ## check when cache is build on the fly while the transformer name is not defined
+        # check when cache is build on the fly while the transformer name is not defined
         cache = DataCache(name="desc2d_transformer2")
         t1 = time.time()
         out1 = cache(smiles, transff)


### PR DESCRIPTION
# Description

This PR removes support for Mordred from Molfeat, since it now conflicts with Numpy 1.24.0 and above.

There are two potential issues to be reviewed:

1. I updated the cache tests to use another descriptor. Everything passes locally, but let me know if that makes sense.
2. The [benchmark notebook](https://github.com/datamol-io/molfeat/blob/main/docs/benchmark.ipynb) references Mordred extensively, but I'm not sure what to do with it.

cc: @hadim, @maclandrol 

# Links
- Issue #63 

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [X ] _Update the API documentation if a new function is added, or an existing one is deleted. Eventually consider making a new tutorial for new features._
- [X] _Write concise and explanatory changelogs below._
- [X ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
