### PR TITLE
Sort the files and save the .bin model file for backwards compatibility

### DIFF
--- a/molfeat/trans/pretrained/hf_transformers.py
+++ b/molfeat/trans/pretrained/hf_transformers.py
@@ -51,10 +51,10 @@ class HFExperiment:
         model.model.save_pretrained(local_path)
         model.tokenizer.save_pretrained(local_path)
 
-        # With transformers>=4.35.0, models are by default saved as safetensors. 
-        # For backwards compatibility, we also save the model as the older pickle-based format. 
+        # With transformers>=4.35.0, models are by default saved as safetensors.
+        # For backwards compatibility, we also save the model as the older pickle-based format.
         model.model.save_pretrained(local_path, safe_serialization=False)
-        
+
         dm.fs.copy_dir(local_path, path, force=True, progress=True, leave_progress=False)
         logger.info(f"Model saved to {path}")
         # clean up now

--- a/molfeat/trans/pretrained/hf_transformers.py
+++ b/molfeat/trans/pretrained/hf_transformers.py
@@ -50,6 +50,11 @@ class HFExperiment:
         # we can save both the tokenizer and the model to the same path
         model.model.save_pretrained(local_path)
         model.tokenizer.save_pretrained(local_path)
+
+        # With transformers>=4.35.0, models are by default saved as safetensors. 
+        # For backwards compatibility, we also save the model as the older pickle-based format. 
+        model.model.save_pretrained(local_path, safe_serialization=False)
+        
         dm.fs.copy_dir(local_path, path, force=True, progress=True, leave_progress=False)
         logger.info(f"Model saved to {path}")
         # clean up now

--- a/molfeat/utils/commons.py
+++ b/molfeat/utils/commons.py
@@ -47,7 +47,7 @@ def sha256sum(filepath: Union[str, os.PathLike]):
     else:
         files = [filepath]
     file_hash = hashlib.sha256()
-    for filepath in files:
+    for filepath in sorted(files):
         with fsspec.open(filepath) as f:
             file_hash.update(f.read())  # type: ignore
     file_hash = file_hash.hexdigest()


### PR DESCRIPTION
## Changelogs

- Tried fixing #84 
  - See the issue for more details, but the ultimate fix was just to reupload the featurizers.
- Also save the `.bin` files, as with `transformer>=4.35.0` the default has changed to `.safetensors` and we want to remain backwards compatible.   

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted. Eventually consider making a new tutorial for new features._~
- [X] _Write concise and explanatory changelogs below._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

