### PR TITLE
PretrainedHFTransformer can use GPUs

### DIFF
--- a/molfeat/trans/pretrained/hf_transformers.py
+++ b/molfeat/trans/pretrained/hf_transformers.py
@@ -210,8 +210,8 @@ class HFModel(PretrainedStoreModel):
             name=self.name, download_path=self.cache_path, store=self.store
         )
         model_path = dm.fs.join(download_output_dir, self.store.MODEL_PATH_NAME)
-        model = HFExperiment.load(model_path)
-        return model
+        self._model = HFExperiment.load(model_path)
+        return self._model
 
 
 class PretrainedHFTransformer(PretrainedMolTransformer):
@@ -300,7 +300,6 @@ class PretrainedHFTransformer(PretrainedMolTransformer):
         else:
             self.kind = kind
             self.featurizer = HFModel(name=self.kind)
-        self.featurizer._model.model.to(self.device)
         self.notation = self.featurizer.get_notation(notation) or "none"
         self.converter = SmilesConverter(self.notation)
         if self.preload:

--- a/molfeat/trans/pretrained/hf_transformers.py
+++ b/molfeat/trans/pretrained/hf_transformers.py
@@ -430,7 +430,7 @@ class PretrainedHFTransformer(PretrainedMolTransformer):
             hidden_state = out_dict["hidden_states"]
             emb_layers = []
             for layer in self.concat_layers:
-                emb = hidden_state[layer].detach().to(self.device)  # B, S, D
+                emb = hidden_state[layer].detach()  # B, S, D
                 emb = self._pooling_obj(
                     emb,
                     inputs["input_ids"],


### PR DESCRIPTION
closes #87 
## Changelogs

-  Fixes #87 where model was not being loaded on GPU for inference.

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted. Eventually consider making a new tutorial for new features._
- [ ] _Write concise and explanatory changelogs below._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
