### PR TITLE
Fix for failing avalon-count FPCalculator

### DIFF
--- a/molfeat/calc/fingerprints.py
+++ b/molfeat/calc/fingerprints.py
@@ -172,6 +172,11 @@ FP_DEF_PARAMS = {
         "fpSize": 2048,
         "atomInvariantsGenerator": None,
     },
+    "avalon-count": {
+        "nBits": 512,
+        "isQuery": False,
+        "bitFlags": pyAvalonTools.avalonSimilarityBits,
+    },    
     "atompair-count": {
         "minDistance": 1,
         "maxDistance": 30,

--- a/molfeat/calc/fingerprints.py
+++ b/molfeat/calc/fingerprints.py
@@ -176,7 +176,7 @@ FP_DEF_PARAMS = {
         "nBits": 512,
         "isQuery": False,
         "bitFlags": pyAvalonTools.avalonSimilarityBits,
-    },    
+    },
     "atompair-count": {
         "minDistance": 1,
         "maxDistance": 30,


### PR DESCRIPTION
Avalon-count calculator fails to initialize due to missing default params in FP_DEF_PARAMS dictionary. Simple fix by adding default parameters for avalon-count fingerprints.

## Changelogs

Updated FP_DEF_PARAMS dictionary.