### PR TITLE
Remove unserializable default params for `pattern` and `layered` fingerprints

### DIFF
--- a/molfeat/calc/fingerprints.py
+++ b/molfeat/calc/fingerprints.py
@@ -109,7 +109,7 @@ FP_DEF_PARAMS = {
     },
     "pattern": {
         "fpSize": 2048,
-        "atomCounts": [],
+        # "atomCounts": [],
         "setOnlyBits": None,
         "tautomerFingerprints": False,
     },
@@ -117,7 +117,7 @@ FP_DEF_PARAMS = {
         "fpSize": 2048,
         "minPath": 1,
         "maxPath": 7,
-        "atomCounts": [],
+        # "atomCounts": [],
         "setOnlyBits": None,
         "branchedPaths": True,
         "fromAtoms": 0,


### PR DESCRIPTION
Removed unhashable list [] params due to failure to use `pattern` and `layered` fingerprint calculators when in dm.parallelized() and in FPVecTransformer(n_jobs=-1).

## Changelogs
Remove list [] params from FP_DEF_PARAMS for `layerd` and `pattern` fingerprints.