### PR TITLE
[fix] Resolve scikit-learn `check_array` deprecation warning 

### DIFF
--- a/molfeat/utils/datatype.py
+++ b/molfeat/utils/datatype.py
@@ -281,6 +281,6 @@ def as_numpy_array_if_possible(arr, dtype: Optional[None]):
                 and np.isscalar(arr[0][0])
             ):
                 return sk_utils.check_array(
-                    arr, accept_sparse=True, force_all_finite=False, ensure_2d=False, allow_nd=True
+                    arr, accept_sparse=True, ensure_all_finite=False, ensure_2d=False, allow_nd=True
                 )
     return arr


### PR DESCRIPTION
Resolves #117 

## Changelogs

- Resolve deprecation/future warning by changing `force_all_finite` to `ensure_all_finite` in call to `sklearn.utils.check_array`

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [X] _Update the API documentation if a new function is added, or an existing one is deleted. Eventually consider making a new tutorial for new features._
- [X] _Write concise and explanatory changelogs below._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---
