### PR TITLE
fix: Github actions workflows +, dependencies fix + cloudflare links

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install black
         run: |
-          pip install black>=24
+          pip install black[jupyter]>=24
 
       - name: Lint
         run: black --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10"]
         os: ["ubuntu-latest"] #, "macos-latest", "windows-latest"]
         pytorch-version: ["1.13"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest"] #, "macos-latest", "windows-latest"]
         pytorch-version: ["1.13"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-latest"] #, "macos-latest", "windows-latest"]
         pytorch-version: ["1.13"]
 
@@ -48,7 +48,7 @@ jobs:
             pytorch=${{ matrix.pytorch-version }}
 
       - name: Install library
-        run: python -m pip install --no-deps .
+        run: python -m pip install --no-deps ".[dev]"
 
       - name: Run pytest
         run: pytest

--- a/docs/tutorials/custom_model_store.ipynb
+++ b/docs/tutorials/custom_model_store.ipynb
@@ -1,1094 +1,1331 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "## Modelstore\n",
-    "\n",
-    "### Introduction\n",
-    "In the last tutorial, we learned how to create our own custom featurizer. In this tutorial, we will guide you through the process of creating a new `modelstore` to store our featurizer cards.\n",
-    "\n",
-    "#### Key concepts of the `modelstore`\n",
-    "The ModelStore class allows you to serialize/register and load models. A `modelstore` is just a path to a bucket or a folder that contains information about our models (artifact such as model weights and a description of the model using the concept of model card).  It also provides functionality to list the available models in the store. Before creating a new model store, let's understand the key concepts:\n",
-    "\n",
-    "* **Model Artifact:** It refers to the serialized representation of a model, typically the model weights or any object that needs to be saved.\n",
-    "\n",
-    "* **Model Card:** It contains information about a model, such as its name, description, and other metadata. The ModelInfo class represents a model card.\n",
-    "\n",
-    "* **Model Store:** It is a path to a bucket or a folder where the model artifacts and model cards are stored.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from molfeat.store import ModelStore\n",
-    "from molfeat.store import ModelInfo"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Model Info Card\n",
-    "\n",
-    "A model (info) card, is a datastructure that describes a model. It has some required arguments such as:\n",
-    "\n",
-    "\n",
-    "```yaml\n",
-    "  # name of the featurizer\n",
-    "  name: ~\n",
-    "  # list of authors\n",
-    "  authors:\n",
-    "    - author 1\n",
-    "  # describe the featurizer\n",
-    "  description: ~\n",
-    "  # which type of input does the featurizer expect ?\n",
-    "  inputs: ~\n",
-    "  # reference of the featurizer (a paper or a link)\n",
-    "  reference: ~\n",
-    "  # what does the featurizer return as output for molecular representation ?\n",
-    "  # one of ['graph', 'line-notation', 'vector', 'tensor', 'other']\n",
-    "  representation: ~\n",
-    "  # does the featurizer require 3D information ?\n",
-    "  require_3D:  ~\n",
-    "  # type of the featurizer, one of [\"pretrained\", \"hand-crafted\", \"hashed\", \"count\"]\n",
-    "  type: ~\n",
-    "  # name of the person that is submitting the featurizer\n",
-    "  submitter: ~\n",
-    "```\n",
-    "\n",
-    "For registration of a model, you will always need to provide the model info card."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
+    "cells":
+    [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata":
+            {
+                "collapsed": false
+            },
+            "outputs":
+            [],
+            "source":
+            [
+                "%load_ext autoreload\n",
+                "%autoreload 2"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {
+                "collapsed": false
+            },
+            "source":
+            [
+                "## Modelstore\n",
+                "\n",
+                "### Introduction\n",
+                "In the last tutorial, we learned how to create our own custom featurizer. In this tutorial, we will guide you through the process of creating a new `modelstore` to store our featurizer cards.\n",
+                "\n",
+                "#### Key concepts of the `modelstore`\n",
+                "The ModelStore class allows you to serialize/register and load models. A `modelstore` is just a path to a bucket or a folder that contains information about our models (artifact such as model weights and a description of the model using the concept of model card).  It also provides functionality to list the available models in the store. Before creating a new model store, let's understand the key concepts:\n",
+                "\n",
+                "* **Model Artifact:** It refers to the serialized representation of a model, typically the model weights or any object that needs to be saved.\n",
+                "\n",
+                "* **Model Card:** It contains information about a model, such as its name, description, and other metadata. The ModelInfo class represents a model card.\n",
+                "\n",
+                "* **Model Store:** It is a path to a bucket or a folder where the model artifacts and model cards are stored.\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "metadata":
+            {
+                "collapsed": false
+            },
+            "outputs":
+            [],
+            "source":
+            [
+                "import os\n",
+                "from molfeat.store import ModelStore\n",
+                "from molfeat.store import ModelInfo"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "#### Model Info Card\n",
+                "\n",
+                "A model (info) card, is a datastructure that describes a model. It has some required arguments such as:\n",
+                "\n",
+                "\n",
+                "```yaml\n",
+                "  # name of the featurizer\n",
+                "  name: ~\n",
+                "  # list of authors\n",
+                "  authors:\n",
+                "    - author 1\n",
+                "  # describe the featurizer\n",
+                "  description: ~\n",
+                "  # which type of input does the featurizer expect ?\n",
+                "  inputs: ~\n",
+                "  # reference of the featurizer (a paper or a link)\n",
+                "  reference: ~\n",
+                "  # what does the featurizer return as output for molecular representation ?\n",
+                "  # one of ['graph', 'line-notation', 'vector', 'tensor', 'other']\n",
+                "  representation: ~\n",
+                "  # does the featurizer require 3D information ?\n",
+                "  require_3D:  ~\n",
+                "  # type of the featurizer, one of [\"pretrained\", \"hand-crafted\", \"hashed\", \"count\"]\n",
+                "  type: ~\n",
+                "  # name of the person that is submitting the featurizer\n",
+                "  submitter: ~\n",
+                "```\n",
+                "\n",
+                "For registration of a model, you will always need to provide the model info card."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "{'name': {'title': 'Name', 'type': 'string'},\n",
+                            " 'inputs': {'title': 'Inputs', 'default': 'smiles', 'type': 'string'},\n",
+                            " 'type': {'title': 'Type',\n",
+                            "  'enum': ['pretrained', 'hand-crafted', 'hashed', 'count'],\n",
+                            "  'type': 'string'},\n",
+                            " 'version': {'title': 'Version', 'default': 0, 'type': 'integer'},\n",
+                            " 'group': {'title': 'Group', 'default': 'all', 'type': 'string'},\n",
+                            " 'submitter': {'title': 'Submitter', 'type': 'string'},\n",
+                            " 'description': {'title': 'Description', 'type': 'string'},\n",
+                            " 'representation': {'title': 'Representation',\n",
+                            "  'enum': ['graph', 'line-notation', 'vector', 'tensor', 'other'],\n",
+                            "  'type': 'string'},\n",
+                            " 'require_3D': {'title': 'Require 3D', 'default': False, 'type': 'boolean'},\n",
+                            " 'tags': {'title': 'Tags', 'type': 'array', 'items': {'type': 'string'}},\n",
+                            " 'authors': {'title': 'Authors', 'type': 'array', 'items': {'type': 'string'}},\n",
+                            " 'reference': {'title': 'Reference', 'type': 'string'},\n",
+                            " 'created_at': {'title': 'Created At',\n",
+                            "  'type': 'string',\n",
+                            "  'format': 'date-time'},\n",
+                            " 'sha256sum': {'title': 'Sha256Sum', 'type': 'string'},\n",
+                            " 'model_usage': {'title': 'Model Usage', 'type': 'string'}}"
+                        ]
+                    },
+                    "execution_count": 3,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "ModelInfo.schema()[\"properties\"]"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "### Creating an instance of ModelStore"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {
+                "collapsed": false
+            },
+            "source":
+            [
+                "The current implementation of the `modelstore` has some limitations:\n",
+                "\n",
+                "- Lack of versioning: The current implementation does not support versioning of models. It treats each model as a unique entity without distinguishing different versions.\n",
+                "\n",
+                "- Unique model names: Each model name must be unique within the store. Duplicate model names are not allowed.\n",
+                "\n",
+                "- Single store support: Currently, a ModelStore instance can only handle a single store, which means it can index and manage models from only one bucket path at a time.\n",
+                "\n",
+                "Now, let's examine the default store."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "'/var/folders/zt/ck4vrp4n4vsb0v16tnlh9h9m0000gn/T/tmp4dqvgaqh'"
+                        ]
+                    },
+                    "execution_count": 4,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "os.environ.pop(\"MOLFEAT_MODEL_STORE_BUCKET\", None)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "metadata":
+            {
+                "collapsed": false
+            },
+            "outputs":
+            [],
+            "source":
+            [
+                "default_store = ModelStore()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "'https://fs.molfeat.datamol.io/artifacts/'"
+                        ]
+                    },
+                    "execution_count": 6,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "default_store.model_store_root"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "45"
+                        ]
+                    },
+                    "execution_count": 7,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "# the length of the model store corresponds to the number of model cards that have been registered\n",
+                "len(default_store)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "[ModelInfo(name='cats2d', inputs='smiles', type='hashed', version=0, group='all', submitter='Datamol', description='2D version of the 6 Potential Pharmacophore Points CATS (Chemically Advanced Template Search) pharmacophore. This version differs from `pharm2D-cats` on the process to make the descriptors fuzzy, which is closer to the original paper implementation. Implementation is based on work by Rajarshi Guha (08/26/07) and Chris Arthur (1/11/2015)', representation='vector', require_3D=False, tags=['CATS', 'hashed', '2D', 'pharmacophore', 'search'], authors=['Michael Reutlinger', 'Christian P Koch', 'Daniel Reker', 'Nickolay Todoroff', 'Petra Schneider', 'Tiago Rodrigues', 'Gisbert Schneider', 'Rajarshi Guha', 'Chris Arthur'], reference='https://doi.org/10.1021/ci050413p', created_at=datetime.datetime(2023, 5, 3, 0, 7, 6, 534648), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
+                            " ModelInfo(name='cats3d', inputs='mol', type='hashed', version=0, group='all', submitter='Datamol', description='3D version of the 6 Potential Pharmacophore Points CATS (Chemically Advanced Template Search) pharmacophore. This version differs from `pharm3D-cats` on the process to make the descriptors fuzzy, which is closer to the original paper implementation. This version uses the 3D distance matrix between pharmacophoric points', representation='vector', require_3D=True, tags=['CATS', 'hashed', '3D', 'pharmacophore', 'search'], authors=['Michael Reutlinger', 'Christian Koch', 'Daniel Reker', 'Nickolay Todoroff', 'Petra Schneider', 'Tiago Rodrigues', 'Gisbert Schneider', 'Rajarshi Guha', 'Chris Arthur'], reference='https://doi.org/10.1021/ci050413p', created_at=datetime.datetime(2023, 5, 3, 0, 7, 9, 952490), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
+                            " ModelInfo(name='mordred', inputs='mol', type='hand-crafted', version=0, group='all', submitter='Datamol', description='Mordred calculates over 1800 molecular descriptors, including constitutional, topological, electronic, and geometrical descriptors, among others. Both 2D and 3D descriptors are supported and optional.', representation='vector', require_3D=False, tags=['topological', 'physchem', 'mordred'], authors=['Hirotomo Moriwaki', 'Yu-Shi Tian', 'Norihito Kawashita', 'Tatsuya Takagi'], reference='https://jcheminf.biomedcentral.com/articles/10.1186/s13321-018-0258-y', created_at=datetime.datetime(2023, 5, 3, 0, 7, 26, 38783), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
+                            " ModelInfo(name='scaffoldkeys', inputs='smiles', type='hand-crafted', version=0, group='all', submitter='Datamol', description='Scaffold Keys are a method for representing scaffold using substructure features and were proposed by Peter Ertl in: Identification of Bioisosteric Scaffolds using Scaffold Keys', representation='vector', require_3D=False, tags=['scaffold', 'bioisosters', 'search'], authors=['Peter Ertl'], reference='https://chemrxiv.org/engage/chemrxiv/article-details/60c7558aee301c5479c7b1be', created_at=datetime.datetime(2023, 5, 3, 0, 7, 22, 832077), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
+                            " ModelInfo(name='gin_supervised_contextpred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and context prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 2, 19, 51, 17, 228390), sha256sum='72dc062936b78b515ed5d0989f909ab7612496d698415d73826b974c9171504a', model_usage=None),\n",
+                            " ModelInfo(name='gin_supervised_edgepred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and edge prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 4, 710823), sha256sum='c1198b37239c3b733f5b48cf265af4c3a1e8c448e2e26cb53e3517fd096213de', model_usage=None),\n",
+                            " ModelInfo(name='gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='78dc0f76cde2151f5aa403cbbffead0f24aeac4ce0b48dbfa2689e1a87b95216', model_usage=None),\n",
+                            " ModelInfo(name='gin_supervised_masking', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with masked modelling on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 9, 221083), sha256sum='c1c797e18312ad44ff089159cb1ed79fd4c67b3d5673c562f61621d95a5d7632', model_usage=None),\n",
+                            " ModelInfo(name='jtvae_zinc_no_kl', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='A JTVAE pre-trained on ZINC for molecule generation, without KL regularization', representation='other', require_3D=False, tags=['JTNN', 'JTVAE', 'dgl', 'pytorch', 'junction-tree', 'graph'], authors=['Wengong Jin', 'Regina Barzilay', 'Tommi Jaakkola'], reference='https://arxiv.org/abs/1802.04364v4', created_at=datetime.datetime(2023, 2, 2, 19, 51, 20, 468939), sha256sum='eab8ecb8a7542a8cdf97410cb27f72aaf374fefef6a1f53642cc5b310cf2b7f6', model_usage=None),\n",
+                            " ModelInfo(name='map4', inputs='smiles', type='hashed', version=0, group='fp', submitter='Datamol', description='MinHashed atom-pair fingerprint up to a diameter of four bonds (MAP4) is suitable for both small and large molecules by combining substructure and atom-pair concepts. In this fingerprint the circular substructures with radii of r\\u2009=\\u20091 and r\\u2009=\\u20092 bonds around each atom in an atom-pair are written as two pairs of SMILES, each pair being combined with the topological distance separating the two central atoms. These so-called atom-pair molecular shingles are hashed, and the resulting set of hashes is MinHashed to form the MAP4 fingerprint.', representation='vector', require_3D=False, tags=['minhashed', 'map4', 'atompair', 'substructure', 'morgan'], authors=['Alice Capecchi', 'Daniel Probst', 'Jean-Louis Reymond'], reference='https://doi.org/10.1186/s13321-020-00445-4', created_at=datetime.datetime(2023, 2, 16, 10, 29, 8, 550063), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None)]"
+                        ]
+                    },
+                    "execution_count": 8,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "default_store.available_models[:10]"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "You can also perform searches within the existing model store using either the full model card (which can be partially instantiated) or the information you have about the model."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "[ModelInfo(name='cats2d', inputs='smiles', type='hashed', version=0, group='all', submitter='Datamol', description='2D version of the 6 Potential Pharmacophore Points CATS (Chemically Advanced Template Search) pharmacophore. This version differs from `pharm2D-cats` on the process to make the descriptors fuzzy, which is closer to the original paper implementation. Implementation is based on work by Rajarshi Guha (08/26/07) and Chris Arthur (1/11/2015)', representation='vector', require_3D=False, tags=['CATS', 'hashed', '2D', 'pharmacophore', 'search'], authors=['Michael Reutlinger', 'Christian P Koch', 'Daniel Reker', 'Nickolay Todoroff', 'Petra Schneider', 'Tiago Rodrigues', 'Gisbert Schneider', 'Rajarshi Guha', 'Chris Arthur'], reference='https://doi.org/10.1021/ci050413p', created_at=datetime.datetime(2023, 5, 3, 0, 7, 6, 534648), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None)]"
+                        ]
+                    },
+                    "execution_count": 9,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "# you can use a model card for the search\n",
+                "my_model_card = default_store.available_models[0]\n",
+                "default_store.search(my_model_card)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "[ModelInfo(name='jtvae_zinc_no_kl', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='A JTVAE pre-trained on ZINC for molecule generation, without KL regularization', representation='other', require_3D=False, tags=['JTNN', 'JTVAE', 'dgl', 'pytorch', 'junction-tree', 'graph'], authors=['Wengong Jin', 'Regina Barzilay', 'Tommi Jaakkola'], reference='https://arxiv.org/abs/1802.04364v4', created_at=datetime.datetime(2023, 2, 2, 19, 51, 20, 468939), sha256sum='eab8ecb8a7542a8cdf97410cb27f72aaf374fefef6a1f53642cc5b310cf2b7f6', model_usage=None)]"
+                        ]
+                    },
+                    "execution_count": 10,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "# search by name\n",
+                "default_store.search(name=\"jtvae_zinc_no_kl\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 11,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "[ModelInfo(name='gin_supervised_contextpred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and context prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 2, 19, 51, 17, 228390), sha256sum='72dc062936b78b515ed5d0989f909ab7612496d698415d73826b974c9171504a', model_usage=None),\n",
+                            " ModelInfo(name='gin_supervised_edgepred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and edge prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 4, 710823), sha256sum='c1198b37239c3b733f5b48cf265af4c3a1e8c448e2e26cb53e3517fd096213de', model_usage=None),\n",
+                            " ModelInfo(name='gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='78dc0f76cde2151f5aa403cbbffead0f24aeac4ce0b48dbfa2689e1a87b95216', model_usage=None),\n",
+                            " ModelInfo(name='gin_supervised_masking', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with masked modelling on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 9, 221083), sha256sum='c1c797e18312ad44ff089159cb1ed79fd4c67b3d5673c562f61621d95a5d7632', model_usage=None),\n",
+                            " ModelInfo(name='pcqm4mv2_graphormer_base', inputs='smiles', type='pretrained', version=0, group='graphormer', submitter='Datamol', description='Pretrained Graph Transformer on PCQM4Mv2 Homo-Lumo energy gap prediction using 2D molecular graphs.', representation='graph', require_3D=False, tags=['Graphormer', 'PCQM4Mv2', 'graph', 'pytorch', 'Microsoft'], authors=['Chengxuan Ying', 'Tianle Cai', 'Shengjie Luo', 'Shuxin Zheng', 'Guolin Ke', 'Di He', 'Yanming Shen', 'Tie-Yan Liu'], reference='https://arxiv.org/abs/2106.05234', created_at=datetime.datetime(2023, 2, 2, 19, 51, 19, 330147), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None)]"
+                        ]
+                    },
+                    "execution_count": 11,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "# Assume you forgot the name of the model, but know it is one of the pretrained models that uses graph as representation\n",
+                "default_store.search(type=\"pretrained\", representation=\"graph\")"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "You can also load models based on their name, <span style=\"color:#ff5050\">this is not the recommended way to explore models, because some models required a custom loading function</span>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "gin_model, gin_model_info = default_store.load(model_name=\"gin_supervised_infomax\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 13,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "ModelInfo(name='gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='78dc0f76cde2151f5aa403cbbffead0f24aeac4ce0b48dbfa2689e1a87b95216', model_usage=None)"
+                        ]
+                    },
+                    "execution_count": 13,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "gin_model_info"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "### Creating a Custom Model Store\n",
+                "\n",
+                "#### Model Store Bucket\n",
+                "\n",
+                "To create a custom model store, you need to specify a model store bucket path. By default, the code uses the read-only model store bucket located at `https://fs.molfeat.datamol.io/artifacts/`. If you want to create a custom `modelstore` that includes the content of the default bucket, you can copy its contents to your custom bucket.\n",
+                "\n",
+                "There are two key concepts to understand when building a custom `modelstore`:\n",
+                "\n",
+                "1. Readable and Writable Path: You need to provide a local or remote folder path that is compatible with [fsspec](https://github.com/fsspec/filesystem_spec). This path will serve as your model store bucket, allowing you to store and access models.\n",
+                "\n",
+                "2. Multiple Model Stores: You can create multiple instances of the `modelstore`, each representing a different model store. However, it's important to note that unless you manually load a model, only models present in the default model store bucket path of the `modelstore` can be loaded by their names. You can override the default model store bucket path by setting the `MOLFEAT_MODEL_STORE_ROOT` environment variable. Currently, we use a single source of truth to simplify the registration and loading process.\n",
+                "\n",
+                "By understanding these concepts, you can create a custom model store by specifying a suitable model store bucket path and optionally copying the content from the default bucket. This allows you to have control over your model store and manage models according to your specific needs."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 14,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "import tempfile\n",
+                "import os"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source": "Let's start with a simple local temporary model store"
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 15,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "[]"
+                        ]
+                    },
+                    "execution_count": 15,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "temp_dir = tempfile.TemporaryDirectory()\n",
+                "temp_model_store = ModelStore(temp_dir.name)\n",
+                "temp_model_store.available_models"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "Let's look at the content of the temp dir"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 16,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text":
+                    [
+                        "/var/folders/zt/ck4vrp4n4vsb0v16tnlh9h9m0000gn/T/tmp5k07n15a\n",
+                        "\n",
+                        "0 directories, 0 files\n"
+                    ]
+                }
+            ],
+            "source":
+            [
+                "%%bash -s \"$temp_dir.name\"\n",
+                "tree $1\n"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "Let's add the GIN model we just downloaded before. To register a new model, you need the following:\n",
+                "\n",
+                "1. Model weights (or None for pretrained models)\n",
+                "2. Model card\n",
+                "3. Serializing function for the model, which determines how to save the model.\n",
+                "\n",
+                "You can also pass additional keyword arguments for your `save_fn` through the `save_fn_kwargs` parameter. The `save_fn` is expected to be called as follows:\n",
+                "\n",
+                "```python\n",
+                "save_fn(model, <model_upload_path>, **save_fn_kwargs)\n",
+                "```\n",
+                "\n",
+                "For example, here's a dummy `save_fn` using PyTorch:\n",
+                "\n",
+                "```python\n",
+                "import torch\n",
+                "import fsspec\n",
+                "def my_torch_save_fn(model, path, **kwargs):\n",
+                "    with fsspec.open(path, 'wb') as f:\n",
+                "        torch.save(model, f, **kwargs)\n",
+                "    return path\n",
+                "```\n",
+                "\n",
+                "Note that if you provide a custom saving function, you are responsible for handling the corresponding loading function that matches your saving function. If you're unsure, it's recommended to use the default loading function, which covers most cases you would encounter."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 17,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "tmp_gin_model_info = gin_model_info.copy()\n",
+                "tmp_gin_model_info.name = \"tmp_gin_supervised_infomax\""
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 18,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "application/vnd.jupyter.widget-view+json":
+                        {
+                            "model_id": "e1229be08fb546448f17610063bd5b81",
+                            "version_major": 2,
+                            "version_minor": 0
+                        },
+                        "text/plain":
+                        [
+                            "  0%|          | 0.00/7.12M [00:00<?, ?B/s]"
+                        ]
+                    },
+                    "metadata":
+                    {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text":
+                    [
+                        "\u001b[32m2023-05-19 15:14:52.082\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmolfeat.store.modelstore\u001b[0m:\u001b[36mregister\u001b[0m:\u001b[36m150\u001b[0m - \u001b[1mSuccessfuly registered model tmp_gin_supervised_infomax !\u001b[0m\n"
+                    ]
+                }
+            ],
+            "source":
+            [
+                "temp_model_store.register(modelcard=tmp_gin_model_info, model=gin_model)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 19,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "[ModelInfo(name='tmp_gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='7a100a7eb680e62d98b0e1d3a906bf740f140dceda55b69a86ddf3fd78ace245', model_usage=None)]"
+                        ]
+                    },
+                    "execution_count": 19,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "temp_model_store.available_models"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 21,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "application/vnd.jupyter.widget-view+json":
+                        {
+                            "model_id": "42768c3c22494cfdb48ccd77528d72f1",
+                            "version_major": 2,
+                            "version_minor": 0
+                        },
+                        "text/plain":
+                        [
+                            "  0%|          | 0.00/663 [00:00<?, ?B/s]"
+                        ]
+                    },
+                    "metadata":
+                    {},
+                    "output_type": "display_data"
+                },
+                {
+                    "data":
+                    {
+                        "application/vnd.jupyter.widget-view+json":
+                        {
+                            "model_id": "489bd797a13e4086a18bc52a075b3cbe",
+                            "version_major": 2,
+                            "version_minor": 0
+                        },
+                        "text/plain":
+                        [
+                            "  0%|          | 0.00/7.12M [00:00<?, ?B/s]"
+                        ]
+                    },
+                    "metadata":
+                    {},
+                    "output_type": "display_data"
+                },
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "(GIN(\n",
+                            "   (dropout): Dropout(p=0.5, inplace=False)\n",
+                            "   (node_embeddings): ModuleList(\n",
+                            "     (0): Embedding(120, 300)\n",
+                            "     (1): Embedding(3, 300)\n",
+                            "   )\n",
+                            "   (gnn_layers): ModuleList(\n",
+                            "     (0): GINLayer(\n",
+                            "       (mlp): Sequential(\n",
+                            "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
+                            "         (1): ReLU()\n",
+                            "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
+                            "       )\n",
+                            "       (edge_embeddings): ModuleList(\n",
+                            "         (0): Embedding(6, 300)\n",
+                            "         (1): Embedding(3, 300)\n",
+                            "       )\n",
+                            "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+                            "     )\n",
+                            "     (1): GINLayer(\n",
+                            "       (mlp): Sequential(\n",
+                            "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
+                            "         (1): ReLU()\n",
+                            "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
+                            "       )\n",
+                            "       (edge_embeddings): ModuleList(\n",
+                            "         (0): Embedding(6, 300)\n",
+                            "         (1): Embedding(3, 300)\n",
+                            "       )\n",
+                            "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+                            "     )\n",
+                            "     (2): GINLayer(\n",
+                            "       (mlp): Sequential(\n",
+                            "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
+                            "         (1): ReLU()\n",
+                            "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
+                            "       )\n",
+                            "       (edge_embeddings): ModuleList(\n",
+                            "         (0): Embedding(6, 300)\n",
+                            "         (1): Embedding(3, 300)\n",
+                            "       )\n",
+                            "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+                            "     )\n",
+                            "     (3): GINLayer(\n",
+                            "       (mlp): Sequential(\n",
+                            "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
+                            "         (1): ReLU()\n",
+                            "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
+                            "       )\n",
+                            "       (edge_embeddings): ModuleList(\n",
+                            "         (0): Embedding(6, 300)\n",
+                            "         (1): Embedding(3, 300)\n",
+                            "       )\n",
+                            "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+                            "     )\n",
+                            "     (4): GINLayer(\n",
+                            "       (mlp): Sequential(\n",
+                            "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
+                            "         (1): ReLU()\n",
+                            "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
+                            "       )\n",
+                            "       (edge_embeddings): ModuleList(\n",
+                            "         (0): Embedding(6, 300)\n",
+                            "         (1): Embedding(3, 300)\n",
+                            "       )\n",
+                            "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+                            "     )\n",
+                            "   )\n",
+                            " ),\n",
+                            " ModelInfo(name='tmp_gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='7a100a7eb680e62d98b0e1d3a906bf740f140dceda55b69a86ddf3fd78ace245', model_usage=None))"
+                        ]
+                    },
+                    "execution_count": 21,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "temp_model_store.load(\"tmp_gin_supervised_infomax\")"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "We can see that the new model `tmp_gin_supervised_infomax` has been saved\n",
+                "\n",
+                "### Loading model from a custom model store"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 22,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "# clean existing env file\n",
+                "! rm -rf .env"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 23,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "import os\n",
+                "from molfeat.trans.pretrained.dgl_pretrained import PretrainedDGLTransformer\n",
+                "\n",
+                "# making sure that the default bucket is not set\n",
+                "model = PretrainedDGLTransformer(kind=\"tmp_gin_supervised_infomax\", dtype=float)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 24,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "'https://fs.molfeat.datamol.io/artifacts/'"
+                        ]
+                    },
+                    "execution_count": 24,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "model.featurizer.store.model_store_root"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 26,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "ename": "ModelStoreError",
+                    "evalue": "Can't retrieve model tmp_gin_supervised_infomax from the store !",
+                    "output_type": "error",
+                    "traceback":
+                    [
+                        "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+                        "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/store/loader.py:99\u001b[0m, in \u001b[0;36mPretrainedStoreModel._load_or_raise\u001b[0;34m(cls, name, download_path, store, **kwargs)\u001b[0m\n\u001b[1;32m     98\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m---> 99\u001b[0m     modelcard \u001b[39m=\u001b[39m store\u001b[39m.\u001b[39;49msearch(name\u001b[39m=\u001b[39;49mname)[\u001b[39m0\u001b[39;49m]\n\u001b[1;32m    100\u001b[0m     artifact_dir \u001b[39m=\u001b[39m store\u001b[39m.\u001b[39mdownload(modelcard, download_path, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs)\n",
+                        "\u001b[0;31mIndexError\u001b[0m: list index out of range",
+                        "\nDuring handling of the above exception, another exception occurred:\n",
+                        "\u001b[0;31mModelStoreError\u001b[0m                           Traceback (most recent call last)",
+                        "\u001b[1;32m/Users/manu/Code/datamol-org/molfeat-core/docs/tutorials/custom_model_store.ipynb Cell 35\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/manu/Code/datamol-org/molfeat-core/docs/tutorials/custom_model_store.ipynb#Y111sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m model([\u001b[39m\"\u001b[39;49m\u001b[39mCCO\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39m\"\u001b[39;49m\u001b[39mCCN\u001b[39;49m\u001b[39m\"\u001b[39;49m])\n",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/base.py:376\u001b[0m, in \u001b[0;36mMoleculeTransformer.__call__\u001b[0;34m(self, mols, enforce_dtype, ignore_errors, **kwargs)\u001b[0m\n\u001b[1;32m    351\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__call__\u001b[39m(\n\u001b[1;32m    352\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    353\u001b[0m     mols: List[Union[dm\u001b[39m.\u001b[39mMol, \u001b[39mstr\u001b[39m]],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    356\u001b[0m     \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs,\n\u001b[1;32m    357\u001b[0m ):\n\u001b[1;32m    358\u001b[0m \u001b[39m    \u001b[39m\u001b[39mr\u001b[39m\u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    359\u001b[0m \u001b[39m    Calculate features for molecules. Using __call__, instead of transform.\u001b[39;00m\n\u001b[1;32m    360\u001b[0m \u001b[39m    If ignore_error is True, a list of features and valid ids are returned.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    374\u001b[0m \n\u001b[1;32m    375\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 376\u001b[0m     features \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mtransform(mols, ignore_errors\u001b[39m=\u001b[39;49mignore_errors, enforce_dtype\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    377\u001b[0m     ids \u001b[39m=\u001b[39m np\u001b[39m.\u001b[39marange(\u001b[39mlen\u001b[39m(features))\n\u001b[1;32m    378\u001b[0m     \u001b[39mif\u001b[39;00m ignore_errors:\n",
+                        "File \u001b[0;32m~/.miniconda/envs/molfeat-dev/lib/python3.10/site-packages/sklearn/utils/_set_output.py:140\u001b[0m, in \u001b[0;36m_wrap_method_output.<locals>.wrapped\u001b[0;34m(self, X, *args, **kwargs)\u001b[0m\n\u001b[1;32m    138\u001b[0m \u001b[39m@wraps\u001b[39m(f)\n\u001b[1;32m    139\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mwrapped\u001b[39m(\u001b[39mself\u001b[39m, X, \u001b[39m*\u001b[39margs, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs):\n\u001b[0;32m--> 140\u001b[0m     data_to_wrap \u001b[39m=\u001b[39m f(\u001b[39mself\u001b[39;49m, X, \u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    141\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(data_to_wrap, \u001b[39mtuple\u001b[39m):\n\u001b[1;32m    142\u001b[0m         \u001b[39m# only wrap the first output for cross decomposition\u001b[39;00m\n\u001b[1;32m    143\u001b[0m         \u001b[39mreturn\u001b[39;00m (\n\u001b[1;32m    144\u001b[0m             _wrap_data_with_container(method, data_to_wrap[\u001b[39m0\u001b[39m], X, \u001b[39mself\u001b[39m),\n\u001b[1;32m    145\u001b[0m             \u001b[39m*\u001b[39mdata_to_wrap[\u001b[39m1\u001b[39m:],\n\u001b[1;32m    146\u001b[0m         )\n",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/base.py:208\u001b[0m, in \u001b[0;36mPretrainedMolTransformer.transform\u001b[0;34m(self, smiles, **kwargs)\u001b[0m\n\u001b[1;32m    206\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mlen\u001b[39m(mols) \u001b[39m>\u001b[39m \u001b[39m0\u001b[39m:\n\u001b[1;32m    207\u001b[0m     converted_mols \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_convert(mols, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs)\n\u001b[0;32m--> 208\u001b[0m     out \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_embed(converted_mols, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    210\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39misinstance\u001b[39m(out, \u001b[39mlist\u001b[39m):\n\u001b[1;32m    211\u001b[0m         out \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(out)\n",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/dgl_pretrained.py:221\u001b[0m, in \u001b[0;36mPretrainedDGLTransformer._embed\u001b[0;34m(self, smiles, **kwargs)\u001b[0m\n\u001b[1;32m    219\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_embed\u001b[39m(\u001b[39mself\u001b[39m, smiles: List[\u001b[39mstr\u001b[39m], \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs):\n\u001b[1;32m    220\u001b[0m \u001b[39m    \u001b[39m\u001b[39m\"\"\"Embed molecules into a latent space\"\"\"\u001b[39;00m\n\u001b[0;32m--> 221\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_preload()\n\u001b[1;32m    222\u001b[0m     dataset, successes \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mgraph_featurizer(smiles, kind\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mkind)\n\u001b[1;32m    223\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mkind \u001b[39min\u001b[39;00m DGLModel\u001b[39m.\u001b[39mavailable_models(query\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m^jtvae\u001b[39m\u001b[39m\"\u001b[39m):\n",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/base.py:90\u001b[0m, in \u001b[0;36mPretrainedMolTransformer._preload\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     88\u001b[0m \u001b[39m\u001b[39m\u001b[39m\"\"\"Preload the pretrained model for later queries\"\"\"\u001b[39;00m\n\u001b[1;32m     89\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfeaturizer \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfeaturizer, PretrainedModel):\n\u001b[0;32m---> 90\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfeaturizer \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mfeaturizer\u001b[39m.\u001b[39;49mload()\n\u001b[1;32m     91\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mpreload \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/dgl_pretrained.py:85\u001b[0m, in \u001b[0;36mDGLModel.load\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     83\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_model \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m     84\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_model\n\u001b[0;32m---> 85\u001b[0m download_output_dir \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_artifact_load(\n\u001b[1;32m     86\u001b[0m     name\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mname, download_path\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mcache_path, store\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mstore\n\u001b[1;32m     87\u001b[0m )\n\u001b[1;32m     88\u001b[0m model_path \u001b[39m=\u001b[39m dm\u001b[39m.\u001b[39mfs\u001b[39m.\u001b[39mjoin(download_output_dir, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mstore\u001b[39m.\u001b[39mMODEL_PATH_NAME)\n\u001b[1;32m     89\u001b[0m \u001b[39mwith\u001b[39;00m fsspec\u001b[39m.\u001b[39mopen(model_path, \u001b[39m\"\u001b[39m\u001b[39mrb\u001b[39m\u001b[39m\"\u001b[39m) \u001b[39mas\u001b[39;00m f:\n",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/store/loader.py:81\u001b[0m, in \u001b[0;36mPretrainedStoreModel._artifact_load\u001b[0;34m(cls, name, download_path, **kwargs)\u001b[0m\n\u001b[1;32m     79\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m dm\u001b[39m.\u001b[39mfs\u001b[39m.\u001b[39mexists(download_path):\n\u001b[1;32m     80\u001b[0m     \u001b[39mcls\u001b[39m\u001b[39m.\u001b[39m_load_or_raise\u001b[39m.\u001b[39mcache_clear()\n\u001b[0;32m---> 81\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mcls\u001b[39;49m\u001b[39m.\u001b[39;49m_load_or_raise(name, download_path, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n",
+                        "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/store/loader.py:103\u001b[0m, in \u001b[0;36mPretrainedStoreModel._load_or_raise\u001b[0;34m(cls, name, download_path, store, **kwargs)\u001b[0m\n\u001b[1;32m    101\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    102\u001b[0m     mess \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mCan\u001b[39m\u001b[39m'\u001b[39m\u001b[39mt retrieve model \u001b[39m\u001b[39m{\u001b[39;00mname\u001b[39m}\u001b[39;00m\u001b[39m from the store !\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 103\u001b[0m     \u001b[39mraise\u001b[39;00m ModelStoreError(mess)\n\u001b[1;32m    104\u001b[0m \u001b[39mreturn\u001b[39;00m artifact_dir\n",
+                        "\u001b[0;31mModelStoreError\u001b[0m: Can't retrieve model tmp_gin_supervised_infomax from the store !"
+                    ]
+                }
+            ],
+            "source":
+            [
+                "model([\"CCO\", \"CCN\"])"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "As expected it's not working, we would need to either load the model first from our store on purpose or change the default loading bucket using the environment variable  `MOLFEAT_MODEL_STORE_BUCKET`.\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 27,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "%%bash -s \"$temp_dir.name\"\n",
+                "echo \"export MOLFEAT_MODEL_STORE_BUCKET=$1\" > .env"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 28,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "# we reimport to reload the store information without restarting the kernel\n",
+                "import dotenv\n",
+                "\n",
+                "dotenv.load_dotenv(override=True)\n",
+                "from molfeat.store import ModelStore  # noqa: E402\n",
+                "\n",
+                "model = PretrainedDGLTransformer(kind=\"tmp_gin_supervised_infomax\", dtype=float)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 29,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "'/var/folders/zt/ck4vrp4n4vsb0v16tnlh9h9m0000gn/T/tmp5k07n15a'"
+                        ]
+                    },
+                    "execution_count": 29,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "model.featurizer.store.model_store_root"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 30,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "(2, 300)"
+                        ]
+                    },
+                    "execution_count": 30,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "model([\"CCO\", \"CCN\"]).shape"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "### Going a bit further: serializing a custom pretrained model into a private model store"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "In the following example, we will explore how to setup a complex pretrained featurizer and load it from a personal modelstore.\n",
+                "\n",
+                "First, we need to install the following library to provide the embeddings. We are following the template from the previous tutorial to show how we can serialize the custom `astrochem_embedding` model into our private store.\n",
+                "\n",
+                "```bash\n",
+                "pip install astrochem_embedding\n",
+                "```"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "For our customd model, we would need to define the loading process which dictates how the model should be loaded from the store.\n",
+                "It's recommended to inherit from `PretrainedStoreModel` if you have a complex loading process."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 31,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "import datamol as dm\n",
+                "import joblib\n",
+                "import fsspec\n",
+                "import torch\n",
+                "\n",
+                "from molfeat.trans.pretrained import PretrainedMolTransformer\n",
+                "from molfeat.store.loader import PretrainedStoreModel\n",
+                "\n",
+                "\n",
+                "class AstroPretrainedStoreModel(PretrainedStoreModel):\n",
+                "    r\"\"\"\n",
+                "    Define a loading class to load the astrochem model from the store\n",
+                "    \"\"\"\n",
+                "\n",
+                "    def load(self):\n",
+                "        \"\"\"Load VICGAE model\"\"\"\n",
+                "        download_output_dir = self._artifact_load(\n",
+                "            name=self.name, download_path=self.cache_path, store=self.store\n",
+                "        )\n",
+                "        model_path = dm.fs.join(download_output_dir, self.store.MODEL_PATH_NAME)\n",
+                "        with fsspec.open(model_path, \"rb\") as f:\n",
+                "            model = joblib.load(f)\n",
+                "        model.eval()\n",
+                "        return model"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 32,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "# We define the model class for loading and transforming data\n",
+                "class MyAstroChemFeaturizer(PretrainedMolTransformer):\n",
+                "    \"\"\"\n",
+                "    In this more practical example, we use embeddings from VICGAE a variance-invariance-covariance\n",
+                "    regularized GRU autoencoder trained on SELFIES strings.\n",
+                "    \"\"\"\n",
+                "\n",
+                "    def __init__(self, name=\"astrochem_embedding\", *args, **kwargs):\n",
+                "        super().__init__(*args, **kwargs)\n",
+                "        # we load the model from the store\n",
+                "        self.model = AstroPretrainedStoreModel(name=name).load()\n",
+                "\n",
+                "    def _embed(self, smiles, **kwargs):\n",
+                "        return [self.model.embed_smiles(x) for x in smiles]"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 38,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "application/vnd.jupyter.widget-view+json":
+                        {
+                            "model_id": "b8b6005f84414a948dba4ca67a5bb815",
+                            "version_major": 2,
+                            "version_minor": 0
+                        },
+                        "text/plain":
+                        [
+                            "  0%|          | 0.00/509k [00:00<?, ?B/s]"
+                        ]
+                    },
+                    "metadata":
+                    {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text":
+                    [
+                        "\u001b[32m2023-05-19 15:16:59.293\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmolfeat.store.modelstore\u001b[0m:\u001b[36mregister\u001b[0m:\u001b[36m150\u001b[0m - \u001b[1mSuccessfuly registered model astrochem_embedding !\u001b[0m\n"
+                    ]
+                }
+            ],
+            "source":
+            [
+                "from astrochem_embedding import VICGAE\n",
+                "\n",
+                "model = VICGAE.from_pretrained()\n",
+                "# Let's define our model's info card and then save the model to the store\n",
+                "info = ModelInfo(\n",
+                "    name=\"astrochem_embedding\",\n",
+                "    inputs=\"selfies\",\n",
+                "    type=\"pretrained\",\n",
+                "    group=\"astrochem\",\n",
+                "    version=0,\n",
+                "    submitter=\"Datamol\",\n",
+                "    description=\"A variance-invariance-covariance regularized GRU autoencoder for astrochemistry using selfies strings!\",\n",
+                "    representation=\"vector\",\n",
+                "    require_3D=False,\n",
+                "    tags=[\"pretrained\", \"astrochemistry\", \"selfies\"],\n",
+                "    authors=[\"Datamol\"],\n",
+                "    reference=\"Lee, K. L. K. (2021). Language models for astrochemistry (Version 0.1.2) [Computer software]. https://github.com/laserkelvin/astrochem_embedding\",\n",
+                ")\n",
+                "\n",
+                "# We define how to use the model using a string that can be displayed in the docs\n",
+                "usage_string = \"\"\"\n",
+                "import torch\n",
+                "import datamol as dm\n",
+                "# <how to import MyAstroChemFeaturizer if needed>\n",
+                "transformer = MyAstroChemFeaturizer(dtype=torch.float)\n",
+                "transformer(dm.freesolv()[\"smiles\"][:10]).shape\n",
+                "\"\"\"\n",
+                "info.set_usage(usage_string)\n",
+                "\n",
+                "# we register the model, this is a simple model that we can just pickle to the store bucket.\n",
+                "temp_model_store.register(info, model=model)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 39,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text":
+                    [
+                        "\n",
+                        "import torch\n",
+                        "import datamol as dm\n",
+                        "# <how to import MyAstroChemFeaturizer if needed>\n",
+                        "transformer = MyAstroChemFeaturizer(dtype=torch.float)\n",
+                        "transformer(dm.freesolv()[\"smiles\"][:10]).shape\n",
+                        "\n"
+                    ]
+                }
+            ],
+            "source":
+            [
+                "print(info.usage())"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 40,
+            "metadata":
+            {},
+            "outputs":
+            [
+                {
+                    "data":
+                    {
+                        "application/vnd.jupyter.widget-view+json":
+                        {
+                            "model_id": "36413f67e3084ac28924eeaf64558e88",
+                            "version_major": 2,
+                            "version_minor": 0
+                        },
+                        "text/plain":
+                        [
+                            "  0%|          | 0.00/882 [00:00<?, ?B/s]"
+                        ]
+                    },
+                    "metadata":
+                    {},
+                    "output_type": "display_data"
+                },
+                {
+                    "data":
+                    {
+                        "application/vnd.jupyter.widget-view+json":
+                        {
+                            "model_id": "46e8469db847407ab4cb17803b2fd5a3",
+                            "version_major": 2,
+                            "version_minor": 0
+                        },
+                        "text/plain":
+                        [
+                            "  0%|          | 0.00/509k [00:00<?, ?B/s]"
+                        ]
+                    },
+                    "metadata":
+                    {},
+                    "output_type": "display_data"
+                },
+                {
+                    "data":
+                    {
+                        "text/plain":
+                        [
+                            "torch.Size([10, 32])"
+                        ]
+                    },
+                    "execution_count": 40,
+                    "metadata":
+                    {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source":
+            [
+                "# let's execute the test example and check\n",
+                "transformer = MyAstroChemFeaturizer(dtype=torch.float)\n",
+                "transformer(dm.freesolv()[\"smiles\"][:10]).shape"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 41,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "# a bit of cleaning\n",
+                "temp_dir.cleanup()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 42,
+            "metadata":
+            {},
+            "outputs":
+            [],
+            "source":
+            [
+                "! rm -rf .env"
+            ]
+        },
+        {
+            "attachments":
+            {},
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "You can now create a private `modelstore` to save, index and share your custom models."
+            ]
+        }
+    ],
+    "metadata":
     {
-     "data": {
-      "text/plain": [
-       "{'name': {'title': 'Name', 'type': 'string'},\n",
-       " 'inputs': {'title': 'Inputs', 'default': 'smiles', 'type': 'string'},\n",
-       " 'type': {'title': 'Type',\n",
-       "  'enum': ['pretrained', 'hand-crafted', 'hashed', 'count'],\n",
-       "  'type': 'string'},\n",
-       " 'version': {'title': 'Version', 'default': 0, 'type': 'integer'},\n",
-       " 'group': {'title': 'Group', 'default': 'all', 'type': 'string'},\n",
-       " 'submitter': {'title': 'Submitter', 'type': 'string'},\n",
-       " 'description': {'title': 'Description', 'type': 'string'},\n",
-       " 'representation': {'title': 'Representation',\n",
-       "  'enum': ['graph', 'line-notation', 'vector', 'tensor', 'other'],\n",
-       "  'type': 'string'},\n",
-       " 'require_3D': {'title': 'Require 3D', 'default': False, 'type': 'boolean'},\n",
-       " 'tags': {'title': 'Tags', 'type': 'array', 'items': {'type': 'string'}},\n",
-       " 'authors': {'title': 'Authors', 'type': 'array', 'items': {'type': 'string'}},\n",
-       " 'reference': {'title': 'Reference', 'type': 'string'},\n",
-       " 'created_at': {'title': 'Created At',\n",
-       "  'type': 'string',\n",
-       "  'format': 'date-time'},\n",
-       " 'sha256sum': {'title': 'Sha256Sum', 'type': 'string'},\n",
-       " 'model_usage': {'title': 'Model Usage', 'type': 'string'}}"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ModelInfo.schema()[\"properties\"]"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Creating an instance of ModelStore"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "The current implementation of the `modelstore` has some limitations:\n",
-    "\n",
-    "- Lack of versioning: The current implementation does not support versioning of models. It treats each model as a unique entity without distinguishing different versions.\n",
-    "\n",
-    "- Unique model names: Each model name must be unique within the store. Duplicate model names are not allowed.\n",
-    "\n",
-    "- Single store support: Currently, a ModelStore instance can only handle a single store, which means it can index and manage models from only one bucket path at a time.\n",
-    "\n",
-    "Now, let's examine the default store."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/var/folders/zt/ck4vrp4n4vsb0v16tnlh9h9m0000gn/T/tmp4dqvgaqh'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "os.environ.pop(\"MOLFEAT_MODEL_STORE_BUCKET\", None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "default_store = ModelStore()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'gs://molfeat-store-prod/artifacts/'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "default_store.model_store_root"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "45"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# the length of the model store corresponds to the number of model cards that have been registered\n",
-    "len(default_store)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[ModelInfo(name='cats2d', inputs='smiles', type='hashed', version=0, group='all', submitter='Datamol', description='2D version of the 6 Potential Pharmacophore Points CATS (Chemically Advanced Template Search) pharmacophore. This version differs from `pharm2D-cats` on the process to make the descriptors fuzzy, which is closer to the original paper implementation. Implementation is based on work by Rajarshi Guha (08/26/07) and Chris Arthur (1/11/2015)', representation='vector', require_3D=False, tags=['CATS', 'hashed', '2D', 'pharmacophore', 'search'], authors=['Michael Reutlinger', 'Christian P Koch', 'Daniel Reker', 'Nickolay Todoroff', 'Petra Schneider', 'Tiago Rodrigues', 'Gisbert Schneider', 'Rajarshi Guha', 'Chris Arthur'], reference='https://doi.org/10.1021/ci050413p', created_at=datetime.datetime(2023, 5, 3, 0, 7, 6, 534648), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
-       " ModelInfo(name='cats3d', inputs='mol', type='hashed', version=0, group='all', submitter='Datamol', description='3D version of the 6 Potential Pharmacophore Points CATS (Chemically Advanced Template Search) pharmacophore. This version differs from `pharm3D-cats` on the process to make the descriptors fuzzy, which is closer to the original paper implementation. This version uses the 3D distance matrix between pharmacophoric points', representation='vector', require_3D=True, tags=['CATS', 'hashed', '3D', 'pharmacophore', 'search'], authors=['Michael Reutlinger', 'Christian Koch', 'Daniel Reker', 'Nickolay Todoroff', 'Petra Schneider', 'Tiago Rodrigues', 'Gisbert Schneider', 'Rajarshi Guha', 'Chris Arthur'], reference='https://doi.org/10.1021/ci050413p', created_at=datetime.datetime(2023, 5, 3, 0, 7, 9, 952490), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
-       " ModelInfo(name='mordred', inputs='mol', type='hand-crafted', version=0, group='all', submitter='Datamol', description='Mordred calculates over 1800 molecular descriptors, including constitutional, topological, electronic, and geometrical descriptors, among others. Both 2D and 3D descriptors are supported and optional.', representation='vector', require_3D=False, tags=['topological', 'physchem', 'mordred'], authors=['Hirotomo Moriwaki', 'Yu-Shi Tian', 'Norihito Kawashita', 'Tatsuya Takagi'], reference='https://jcheminf.biomedcentral.com/articles/10.1186/s13321-018-0258-y', created_at=datetime.datetime(2023, 5, 3, 0, 7, 26, 38783), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
-       " ModelInfo(name='scaffoldkeys', inputs='smiles', type='hand-crafted', version=0, group='all', submitter='Datamol', description='Scaffold Keys are a method for representing scaffold using substructure features and were proposed by Peter Ertl in: Identification of Bioisosteric Scaffolds using Scaffold Keys', representation='vector', require_3D=False, tags=['scaffold', 'bioisosters', 'search'], authors=['Peter Ertl'], reference='https://chemrxiv.org/engage/chemrxiv/article-details/60c7558aee301c5479c7b1be', created_at=datetime.datetime(2023, 5, 3, 0, 7, 22, 832077), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None),\n",
-       " ModelInfo(name='gin_supervised_contextpred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and context prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 2, 19, 51, 17, 228390), sha256sum='72dc062936b78b515ed5d0989f909ab7612496d698415d73826b974c9171504a', model_usage=None),\n",
-       " ModelInfo(name='gin_supervised_edgepred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and edge prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 4, 710823), sha256sum='c1198b37239c3b733f5b48cf265af4c3a1e8c448e2e26cb53e3517fd096213de', model_usage=None),\n",
-       " ModelInfo(name='gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='78dc0f76cde2151f5aa403cbbffead0f24aeac4ce0b48dbfa2689e1a87b95216', model_usage=None),\n",
-       " ModelInfo(name='gin_supervised_masking', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with masked modelling on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 9, 221083), sha256sum='c1c797e18312ad44ff089159cb1ed79fd4c67b3d5673c562f61621d95a5d7632', model_usage=None),\n",
-       " ModelInfo(name='jtvae_zinc_no_kl', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='A JTVAE pre-trained on ZINC for molecule generation, without KL regularization', representation='other', require_3D=False, tags=['JTNN', 'JTVAE', 'dgl', 'pytorch', 'junction-tree', 'graph'], authors=['Wengong Jin', 'Regina Barzilay', 'Tommi Jaakkola'], reference='https://arxiv.org/abs/1802.04364v4', created_at=datetime.datetime(2023, 2, 2, 19, 51, 20, 468939), sha256sum='eab8ecb8a7542a8cdf97410cb27f72aaf374fefef6a1f53642cc5b310cf2b7f6', model_usage=None),\n",
-       " ModelInfo(name='map4', inputs='smiles', type='hashed', version=0, group='fp', submitter='Datamol', description='MinHashed atom-pair fingerprint up to a diameter of four bonds (MAP4) is suitable for both small and large molecules by combining substructure and atom-pair concepts. In this fingerprint the circular substructures with radii of r\\u2009=\\u20091 and r\\u2009=\\u20092 bonds around each atom in an atom-pair are written as two pairs of SMILES, each pair being combined with the topological distance separating the two central atoms. These so-called atom-pair molecular shingles are hashed, and the resulting set of hashes is MinHashed to form the MAP4 fingerprint.', representation='vector', require_3D=False, tags=['minhashed', 'map4', 'atompair', 'substructure', 'morgan'], authors=['Alice Capecchi', 'Daniel Probst', 'Jean-Louis Reymond'], reference='https://doi.org/10.1186/s13321-020-00445-4', created_at=datetime.datetime(2023, 2, 16, 10, 29, 8, 550063), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None)]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "default_store.available_models[:10]"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also perform searches within the existing model store using either the full model card (which can be partially instantiated) or the information you have about the model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[ModelInfo(name='cats2d', inputs='smiles', type='hashed', version=0, group='all', submitter='Datamol', description='2D version of the 6 Potential Pharmacophore Points CATS (Chemically Advanced Template Search) pharmacophore. This version differs from `pharm2D-cats` on the process to make the descriptors fuzzy, which is closer to the original paper implementation. Implementation is based on work by Rajarshi Guha (08/26/07) and Chris Arthur (1/11/2015)', representation='vector', require_3D=False, tags=['CATS', 'hashed', '2D', 'pharmacophore', 'search'], authors=['Michael Reutlinger', 'Christian P Koch', 'Daniel Reker', 'Nickolay Todoroff', 'Petra Schneider', 'Tiago Rodrigues', 'Gisbert Schneider', 'Rajarshi Guha', 'Chris Arthur'], reference='https://doi.org/10.1021/ci050413p', created_at=datetime.datetime(2023, 5, 3, 0, 7, 6, 534648), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None)]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# you can use a model card for the search\n",
-    "my_model_card = default_store.available_models[0]\n",
-    "default_store.search(my_model_card)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[ModelInfo(name='jtvae_zinc_no_kl', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='A JTVAE pre-trained on ZINC for molecule generation, without KL regularization', representation='other', require_3D=False, tags=['JTNN', 'JTVAE', 'dgl', 'pytorch', 'junction-tree', 'graph'], authors=['Wengong Jin', 'Regina Barzilay', 'Tommi Jaakkola'], reference='https://arxiv.org/abs/1802.04364v4', created_at=datetime.datetime(2023, 2, 2, 19, 51, 20, 468939), sha256sum='eab8ecb8a7542a8cdf97410cb27f72aaf374fefef6a1f53642cc5b310cf2b7f6', model_usage=None)]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# search by name\n",
-    "default_store.search(name=\"jtvae_zinc_no_kl\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[ModelInfo(name='gin_supervised_contextpred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and context prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 2, 19, 51, 17, 228390), sha256sum='72dc062936b78b515ed5d0989f909ab7612496d698415d73826b974c9171504a', model_usage=None),\n",
-       " ModelInfo(name='gin_supervised_edgepred', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with supervised learning and edge prediction on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 4, 710823), sha256sum='c1198b37239c3b733f5b48cf265af4c3a1e8c448e2e26cb53e3517fd096213de', model_usage=None),\n",
-       " ModelInfo(name='gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='78dc0f76cde2151f5aa403cbbffead0f24aeac4ce0b48dbfa2689e1a87b95216', model_usage=None),\n",
-       " ModelInfo(name='gin_supervised_masking', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with masked modelling on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 9, 221083), sha256sum='c1c797e18312ad44ff089159cb1ed79fd4c67b3d5673c562f61621d95a5d7632', model_usage=None),\n",
-       " ModelInfo(name='pcqm4mv2_graphormer_base', inputs='smiles', type='pretrained', version=0, group='graphormer', submitter='Datamol', description='Pretrained Graph Transformer on PCQM4Mv2 Homo-Lumo energy gap prediction using 2D molecular graphs.', representation='graph', require_3D=False, tags=['Graphormer', 'PCQM4Mv2', 'graph', 'pytorch', 'Microsoft'], authors=['Chengxuan Ying', 'Tianle Cai', 'Shengjie Luo', 'Shuxin Zheng', 'Guolin Ke', 'Di He', 'Yanming Shen', 'Tie-Yan Liu'], reference='https://arxiv.org/abs/2106.05234', created_at=datetime.datetime(2023, 2, 2, 19, 51, 19, 330147), sha256sum='9c298d589a2158eb513cb52191144518a2acab2cb0c04f1df14fca0f712fa4a1', model_usage=None)]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Assume you forgot the name of the model, but know it is one of the pretrained models that uses graph as representation\n",
-    "default_store.search(type=\"pretrained\", representation=\"graph\")"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also load models based on their name, <span style=\"color:#ff5050\">this is not the recommended way to explore models, because some models required a custom loading function</span>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gin_model, gin_model_info = default_store.load(model_name=\"gin_supervised_infomax\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ModelInfo(name='gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='78dc0f76cde2151f5aa403cbbffead0f24aeac4ce0b48dbfa2689e1a87b95216', model_usage=None)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "gin_model_info"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Creating a Custom Model Store\n",
-    "\n",
-    "#### Model Store Bucket\n",
-    "\n",
-    "To create a custom model store, you need to specify a model store bucket path. By default, the code uses the read-only model store bucket located at `gs://molfeat-store-prod/artifacts/`. If you want to create a custom `modelstore` that includes the content of the default bucket, you can copy its contents to your custom bucket.\n",
-    "\n",
-    "There are two key concepts to understand when building a custom `modelstore`:\n",
-    "\n",
-    "1. Readable and Writable Path: You need to provide a local or remote folder path that is compatible with [fsspec](https://github.com/fsspec/filesystem_spec). This path will serve as your model store bucket, allowing you to store and access models.\n",
-    "\n",
-    "2. Multiple Model Stores: You can create multiple instances of the `modelstore`, each representing a different model store. However, it's important to note that unless you manually load a model, only models present in the default model store bucket path of the `modelstore` can be loaded by their names. You can override the default model store bucket path by setting the `MOLFEAT_MODEL_STORE_ROOT` environment variable. Currently, we use a single source of truth to simplify the registration and loading process.\n",
-    "\n",
-    "By understanding these concepts, you can create a custom model store by specifying a suitable model store bucket path and optionally copying the content from the default bucket. This allows you to have control over your model store and manage models according to your specific needs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tempfile\n",
-    "import os"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "Let's start with a simple local temporary model store"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "temp_dir = tempfile.TemporaryDirectory()\n",
-    "temp_model_store = ModelStore(temp_dir.name)\n",
-    "temp_model_store.available_models"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's look at the content of the temp dir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/zt/ck4vrp4n4vsb0v16tnlh9h9m0000gn/T/tmp5k07n15a\n",
-      "\n",
-      "0 directories, 0 files\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash -s \"$temp_dir.name\"\n",
-    "tree $1\n"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's add the GIN model we just downloaded before. To register a new model, you need the following:\n",
-    "\n",
-    "1. Model weights (or None for pretrained models)\n",
-    "2. Model card\n",
-    "3. Serializing function for the model, which determines how to save the model.\n",
-    "\n",
-    "You can also pass additional keyword arguments for your `save_fn` through the `save_fn_kwargs` parameter. The `save_fn` is expected to be called as follows:\n",
-    "\n",
-    "```python\n",
-    "save_fn(model, <model_upload_path>, **save_fn_kwargs)\n",
-    "```\n",
-    "\n",
-    "For example, here's a dummy `save_fn` using PyTorch:\n",
-    "\n",
-    "```python\n",
-    "import torch\n",
-    "import fsspec\n",
-    "def my_torch_save_fn(model, path, **kwargs):\n",
-    "    with fsspec.open(path, 'wb') as f:\n",
-    "        torch.save(model, f, **kwargs)\n",
-    "    return path\n",
-    "```\n",
-    "\n",
-    "Note that if you provide a custom saving function, you are responsible for handling the corresponding loading function that matches your saving function. If you're unsure, it's recommended to use the default loading function, which covers most cases you would encounter."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tmp_gin_model_info = gin_model_info.copy()\n",
-    "tmp_gin_model_info.name = \"tmp_gin_supervised_infomax\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e1229be08fb546448f17610063bd5b81",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0.00/7.12M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+        "kernelspec":
+        {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info":
+        {
+            "codemirror_mode":
+            {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.10"
+        }
     },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2023-05-19 15:14:52.082\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmolfeat.store.modelstore\u001b[0m:\u001b[36mregister\u001b[0m:\u001b[36m150\u001b[0m - \u001b[1mSuccessfuly registered model tmp_gin_supervised_infomax !\u001b[0m\n"
-     ]
-    }
-   ],
-   "source": [
-    "temp_model_store.register(modelcard=tmp_gin_model_info, model=gin_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[ModelInfo(name='tmp_gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='7a100a7eb680e62d98b0e1d3a906bf740f140dceda55b69a86ddf3fd78ace245', model_usage=None)]"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "temp_model_store.available_models"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "42768c3c22494cfdb48ccd77528d72f1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0.00/663 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "489bd797a13e4086a18bc52a075b3cbe",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0.00/7.12M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(GIN(\n",
-       "   (dropout): Dropout(p=0.5, inplace=False)\n",
-       "   (node_embeddings): ModuleList(\n",
-       "     (0): Embedding(120, 300)\n",
-       "     (1): Embedding(3, 300)\n",
-       "   )\n",
-       "   (gnn_layers): ModuleList(\n",
-       "     (0): GINLayer(\n",
-       "       (mlp): Sequential(\n",
-       "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
-       "         (1): ReLU()\n",
-       "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
-       "       )\n",
-       "       (edge_embeddings): ModuleList(\n",
-       "         (0): Embedding(6, 300)\n",
-       "         (1): Embedding(3, 300)\n",
-       "       )\n",
-       "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "     )\n",
-       "     (1): GINLayer(\n",
-       "       (mlp): Sequential(\n",
-       "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
-       "         (1): ReLU()\n",
-       "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
-       "       )\n",
-       "       (edge_embeddings): ModuleList(\n",
-       "         (0): Embedding(6, 300)\n",
-       "         (1): Embedding(3, 300)\n",
-       "       )\n",
-       "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "     )\n",
-       "     (2): GINLayer(\n",
-       "       (mlp): Sequential(\n",
-       "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
-       "         (1): ReLU()\n",
-       "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
-       "       )\n",
-       "       (edge_embeddings): ModuleList(\n",
-       "         (0): Embedding(6, 300)\n",
-       "         (1): Embedding(3, 300)\n",
-       "       )\n",
-       "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "     )\n",
-       "     (3): GINLayer(\n",
-       "       (mlp): Sequential(\n",
-       "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
-       "         (1): ReLU()\n",
-       "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
-       "       )\n",
-       "       (edge_embeddings): ModuleList(\n",
-       "         (0): Embedding(6, 300)\n",
-       "         (1): Embedding(3, 300)\n",
-       "       )\n",
-       "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "     )\n",
-       "     (4): GINLayer(\n",
-       "       (mlp): Sequential(\n",
-       "         (0): Linear(in_features=300, out_features=600, bias=True)\n",
-       "         (1): ReLU()\n",
-       "         (2): Linear(in_features=600, out_features=300, bias=True)\n",
-       "       )\n",
-       "       (edge_embeddings): ModuleList(\n",
-       "         (0): Embedding(6, 300)\n",
-       "         (1): Embedding(3, 300)\n",
-       "       )\n",
-       "       (bn): BatchNorm1d(300, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "     )\n",
-       "   )\n",
-       " ),\n",
-       " ModelInfo(name='tmp_gin_supervised_infomax', inputs='smiles', type='pretrained', version=0, group='dgllife', submitter='Datamol', description='GIN neural network model pre-trained with mutual information maximisation on molecules from ChEMBL.', representation='graph', require_3D=False, tags=['GIN', 'dgl', 'pytorch', 'graph'], authors=['Weihua Hu', 'Bowen Liu', 'Joseph Gomes', 'Marinka Zitnik', 'Percy Liang', 'Vijay Pande', 'Jure Leskovec'], reference='https://arxiv.org/abs/1905.12265', created_at=datetime.datetime(2023, 2, 14, 17, 42, 6, 967631), sha256sum='7a100a7eb680e62d98b0e1d3a906bf740f140dceda55b69a86ddf3fd78ace245', model_usage=None))"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "temp_model_store.load(\"tmp_gin_supervised_infomax\")"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can see that the new model `tmp_gin_supervised_infomax` has been saved\n",
-    "\n",
-    "### Loading model from a custom model store"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# clean existing env file\n",
-    "! rm -rf .env"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from molfeat.trans.pretrained.dgl_pretrained import PretrainedDGLTransformer\n",
-    "\n",
-    "# making sure that the default bucket is not set\n",
-    "model = PretrainedDGLTransformer(kind=\"tmp_gin_supervised_infomax\", dtype=float)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'gs://molfeat-store-prod/artifacts/'"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model.featurizer.store.model_store_root"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModelStoreError",
-     "evalue": "Can't retrieve model tmp_gin_supervised_infomax from the store !",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/store/loader.py:99\u001b[0m, in \u001b[0;36mPretrainedStoreModel._load_or_raise\u001b[0;34m(cls, name, download_path, store, **kwargs)\u001b[0m\n\u001b[1;32m     98\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m---> 99\u001b[0m     modelcard \u001b[39m=\u001b[39m store\u001b[39m.\u001b[39;49msearch(name\u001b[39m=\u001b[39;49mname)[\u001b[39m0\u001b[39;49m]\n\u001b[1;32m    100\u001b[0m     artifact_dir \u001b[39m=\u001b[39m store\u001b[39m.\u001b[39mdownload(modelcard, download_path, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs)\n",
-      "\u001b[0;31mIndexError\u001b[0m: list index out of range",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mModelStoreError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[1;32m/Users/manu/Code/datamol-org/molfeat-core/docs/tutorials/custom_model_store.ipynb Cell 35\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/manu/Code/datamol-org/molfeat-core/docs/tutorials/custom_model_store.ipynb#Y111sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m model([\u001b[39m\"\u001b[39;49m\u001b[39mCCO\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39m\"\u001b[39;49m\u001b[39mCCN\u001b[39;49m\u001b[39m\"\u001b[39;49m])\n",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/base.py:376\u001b[0m, in \u001b[0;36mMoleculeTransformer.__call__\u001b[0;34m(self, mols, enforce_dtype, ignore_errors, **kwargs)\u001b[0m\n\u001b[1;32m    351\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__call__\u001b[39m(\n\u001b[1;32m    352\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    353\u001b[0m     mols: List[Union[dm\u001b[39m.\u001b[39mMol, \u001b[39mstr\u001b[39m]],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    356\u001b[0m     \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs,\n\u001b[1;32m    357\u001b[0m ):\n\u001b[1;32m    358\u001b[0m \u001b[39m    \u001b[39m\u001b[39mr\u001b[39m\u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    359\u001b[0m \u001b[39m    Calculate features for molecules. Using __call__, instead of transform.\u001b[39;00m\n\u001b[1;32m    360\u001b[0m \u001b[39m    If ignore_error is True, a list of features and valid ids are returned.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    374\u001b[0m \n\u001b[1;32m    375\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 376\u001b[0m     features \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mtransform(mols, ignore_errors\u001b[39m=\u001b[39;49mignore_errors, enforce_dtype\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    377\u001b[0m     ids \u001b[39m=\u001b[39m np\u001b[39m.\u001b[39marange(\u001b[39mlen\u001b[39m(features))\n\u001b[1;32m    378\u001b[0m     \u001b[39mif\u001b[39;00m ignore_errors:\n",
-      "File \u001b[0;32m~/.miniconda/envs/molfeat-dev/lib/python3.10/site-packages/sklearn/utils/_set_output.py:140\u001b[0m, in \u001b[0;36m_wrap_method_output.<locals>.wrapped\u001b[0;34m(self, X, *args, **kwargs)\u001b[0m\n\u001b[1;32m    138\u001b[0m \u001b[39m@wraps\u001b[39m(f)\n\u001b[1;32m    139\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mwrapped\u001b[39m(\u001b[39mself\u001b[39m, X, \u001b[39m*\u001b[39margs, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs):\n\u001b[0;32m--> 140\u001b[0m     data_to_wrap \u001b[39m=\u001b[39m f(\u001b[39mself\u001b[39;49m, X, \u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    141\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(data_to_wrap, \u001b[39mtuple\u001b[39m):\n\u001b[1;32m    142\u001b[0m         \u001b[39m# only wrap the first output for cross decomposition\u001b[39;00m\n\u001b[1;32m    143\u001b[0m         \u001b[39mreturn\u001b[39;00m (\n\u001b[1;32m    144\u001b[0m             _wrap_data_with_container(method, data_to_wrap[\u001b[39m0\u001b[39m], X, \u001b[39mself\u001b[39m),\n\u001b[1;32m    145\u001b[0m             \u001b[39m*\u001b[39mdata_to_wrap[\u001b[39m1\u001b[39m:],\n\u001b[1;32m    146\u001b[0m         )\n",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/base.py:208\u001b[0m, in \u001b[0;36mPretrainedMolTransformer.transform\u001b[0;34m(self, smiles, **kwargs)\u001b[0m\n\u001b[1;32m    206\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mlen\u001b[39m(mols) \u001b[39m>\u001b[39m \u001b[39m0\u001b[39m:\n\u001b[1;32m    207\u001b[0m     converted_mols \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_convert(mols, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs)\n\u001b[0;32m--> 208\u001b[0m     out \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_embed(converted_mols, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    210\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39misinstance\u001b[39m(out, \u001b[39mlist\u001b[39m):\n\u001b[1;32m    211\u001b[0m         out \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(out)\n",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/dgl_pretrained.py:221\u001b[0m, in \u001b[0;36mPretrainedDGLTransformer._embed\u001b[0;34m(self, smiles, **kwargs)\u001b[0m\n\u001b[1;32m    219\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_embed\u001b[39m(\u001b[39mself\u001b[39m, smiles: List[\u001b[39mstr\u001b[39m], \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs):\n\u001b[1;32m    220\u001b[0m \u001b[39m    \u001b[39m\u001b[39m\"\"\"Embed molecules into a latent space\"\"\"\u001b[39;00m\n\u001b[0;32m--> 221\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_preload()\n\u001b[1;32m    222\u001b[0m     dataset, successes \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mgraph_featurizer(smiles, kind\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mkind)\n\u001b[1;32m    223\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mkind \u001b[39min\u001b[39;00m DGLModel\u001b[39m.\u001b[39mavailable_models(query\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m^jtvae\u001b[39m\u001b[39m\"\u001b[39m):\n",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/base.py:90\u001b[0m, in \u001b[0;36mPretrainedMolTransformer._preload\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     88\u001b[0m \u001b[39m\u001b[39m\u001b[39m\"\"\"Preload the pretrained model for later queries\"\"\"\u001b[39;00m\n\u001b[1;32m     89\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfeaturizer \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfeaturizer, PretrainedModel):\n\u001b[0;32m---> 90\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfeaturizer \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mfeaturizer\u001b[39m.\u001b[39;49mload()\n\u001b[1;32m     91\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mpreload \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/trans/pretrained/dgl_pretrained.py:85\u001b[0m, in \u001b[0;36mDGLModel.load\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     83\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_model \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m     84\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_model\n\u001b[0;32m---> 85\u001b[0m download_output_dir \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_artifact_load(\n\u001b[1;32m     86\u001b[0m     name\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mname, download_path\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mcache_path, store\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mstore\n\u001b[1;32m     87\u001b[0m )\n\u001b[1;32m     88\u001b[0m model_path \u001b[39m=\u001b[39m dm\u001b[39m.\u001b[39mfs\u001b[39m.\u001b[39mjoin(download_output_dir, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mstore\u001b[39m.\u001b[39mMODEL_PATH_NAME)\n\u001b[1;32m     89\u001b[0m \u001b[39mwith\u001b[39;00m fsspec\u001b[39m.\u001b[39mopen(model_path, \u001b[39m\"\u001b[39m\u001b[39mrb\u001b[39m\u001b[39m\"\u001b[39m) \u001b[39mas\u001b[39;00m f:\n",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/store/loader.py:81\u001b[0m, in \u001b[0;36mPretrainedStoreModel._artifact_load\u001b[0;34m(cls, name, download_path, **kwargs)\u001b[0m\n\u001b[1;32m     79\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m dm\u001b[39m.\u001b[39mfs\u001b[39m.\u001b[39mexists(download_path):\n\u001b[1;32m     80\u001b[0m     \u001b[39mcls\u001b[39m\u001b[39m.\u001b[39m_load_or_raise\u001b[39m.\u001b[39mcache_clear()\n\u001b[0;32m---> 81\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mcls\u001b[39;49m\u001b[39m.\u001b[39;49m_load_or_raise(name, download_path, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n",
-      "File \u001b[0;32m~/Code/datamol-org/molfeat-core/molfeat/store/loader.py:103\u001b[0m, in \u001b[0;36mPretrainedStoreModel._load_or_raise\u001b[0;34m(cls, name, download_path, store, **kwargs)\u001b[0m\n\u001b[1;32m    101\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    102\u001b[0m     mess \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mCan\u001b[39m\u001b[39m'\u001b[39m\u001b[39mt retrieve model \u001b[39m\u001b[39m{\u001b[39;00mname\u001b[39m}\u001b[39;00m\u001b[39m from the store !\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 103\u001b[0m     \u001b[39mraise\u001b[39;00m ModelStoreError(mess)\n\u001b[1;32m    104\u001b[0m \u001b[39mreturn\u001b[39;00m artifact_dir\n",
-      "\u001b[0;31mModelStoreError\u001b[0m: Can't retrieve model tmp_gin_supervised_infomax from the store !"
-     ]
-    }
-   ],
-   "source": [
-    "model([\"CCO\", \"CCN\"])"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As expected it's not working, we would need to either load the model first from our store on purpose or change the default loading bucket using the environment variable  `MOLFEAT_MODEL_STORE_BUCKET`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash -s \"$temp_dir.name\"\n",
-    "echo \"export MOLFEAT_MODEL_STORE_BUCKET=$1\" > .env"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# we reimport to reload the store information without restarting the kernel\n",
-    "import dotenv\n",
-    "\n",
-    "dotenv.load_dotenv(override=True)\n",
-    "from molfeat.store import ModelStore  # noqa: E402\n",
-    "\n",
-    "model = PretrainedDGLTransformer(kind=\"tmp_gin_supervised_infomax\", dtype=float)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/var/folders/zt/ck4vrp4n4vsb0v16tnlh9h9m0000gn/T/tmp5k07n15a'"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model.featurizer.store.model_store_root"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(2, 300)"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model([\"CCO\", \"CCN\"]).shape"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Going a bit further: serializing a custom pretrained model into a private model store"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In the following example, we will explore how to setup a complex pretrained featurizer and load it from a personal modelstore.\n",
-    "\n",
-    "First, we need to install the following library to provide the embeddings. We are following the template from the previous tutorial to show how we can serialize the custom `astrochem_embedding` model into our private store.\n",
-    "\n",
-    "```bash\n",
-    "pip install astrochem_embedding\n",
-    "```"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For our customd model, we would need to define the loading process which dictates how the model should be loaded from the store.\n",
-    "It's recommended to inherit from `PretrainedStoreModel` if you have a complex loading process."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import datamol as dm\n",
-    "import joblib\n",
-    "import fsspec\n",
-    "import torch\n",
-    "\n",
-    "from molfeat.trans.pretrained import PretrainedMolTransformer\n",
-    "from molfeat.store.loader import PretrainedStoreModel\n",
-    "\n",
-    "\n",
-    "class AstroPretrainedStoreModel(PretrainedStoreModel):\n",
-    "    r\"\"\"\n",
-    "    Define a loading class to load the astrochem model from the store\n",
-    "    \"\"\"\n",
-    "\n",
-    "    def load(self):\n",
-    "        \"\"\"Load VICGAE model\"\"\"\n",
-    "        download_output_dir = self._artifact_load(\n",
-    "            name=self.name, download_path=self.cache_path, store=self.store\n",
-    "        )\n",
-    "        model_path = dm.fs.join(download_output_dir, self.store.MODEL_PATH_NAME)\n",
-    "        with fsspec.open(model_path, \"rb\") as f:\n",
-    "            model = joblib.load(f)\n",
-    "        model.eval()\n",
-    "        return model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We define the model class for loading and transforming data\n",
-    "class MyAstroChemFeaturizer(PretrainedMolTransformer):\n",
-    "    \"\"\"\n",
-    "    In this more practical example, we use embeddings from VICGAE a variance-invariance-covariance\n",
-    "    regularized GRU autoencoder trained on SELFIES strings.\n",
-    "    \"\"\"\n",
-    "\n",
-    "    def __init__(self, name=\"astrochem_embedding\", *args, **kwargs):\n",
-    "        super().__init__(*args, **kwargs)\n",
-    "        # we load the model from the store\n",
-    "        self.model = AstroPretrainedStoreModel(name=name).load()\n",
-    "\n",
-    "    def _embed(self, smiles, **kwargs):\n",
-    "        return [self.model.embed_smiles(x) for x in smiles]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b8b6005f84414a948dba4ca67a5bb815",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0.00/509k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2023-05-19 15:16:59.293\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmolfeat.store.modelstore\u001b[0m:\u001b[36mregister\u001b[0m:\u001b[36m150\u001b[0m - \u001b[1mSuccessfuly registered model astrochem_embedding !\u001b[0m\n"
-     ]
-    }
-   ],
-   "source": [
-    "from astrochem_embedding import VICGAE\n",
-    "\n",
-    "model = VICGAE.from_pretrained()\n",
-    "# Let's define our model's info card and then save the model to the store\n",
-    "info = ModelInfo(\n",
-    "    name=\"astrochem_embedding\",\n",
-    "    inputs=\"selfies\",\n",
-    "    type=\"pretrained\",\n",
-    "    group=\"astrochem\",\n",
-    "    version=0,\n",
-    "    submitter=\"Datamol\",\n",
-    "    description=\"A variance-invariance-covariance regularized GRU autoencoder for astrochemistry using selfies strings!\",\n",
-    "    representation=\"vector\",\n",
-    "    require_3D=False,\n",
-    "    tags=[\"pretrained\", \"astrochemistry\", \"selfies\"],\n",
-    "    authors=[\"Datamol\"],\n",
-    "    reference=\"Lee, K. L. K. (2021). Language models for astrochemistry (Version 0.1.2) [Computer software]. https://github.com/laserkelvin/astrochem_embedding\",\n",
-    ")\n",
-    "\n",
-    "# We define how to use the model using a string that can be displayed in the docs\n",
-    "usage_string = \"\"\"\n",
-    "import torch\n",
-    "import datamol as dm\n",
-    "# <how to import MyAstroChemFeaturizer if needed>\n",
-    "transformer = MyAstroChemFeaturizer(dtype=torch.float)\n",
-    "transformer(dm.freesolv()[\"smiles\"][:10]).shape\n",
-    "\"\"\"\n",
-    "info.set_usage(usage_string)\n",
-    "\n",
-    "# we register the model, this is a simple model that we can just pickle to the store bucket.\n",
-    "temp_model_store.register(info, model=model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "import torch\n",
-      "import datamol as dm\n",
-      "# <how to import MyAstroChemFeaturizer if needed>\n",
-      "transformer = MyAstroChemFeaturizer(dtype=torch.float)\n",
-      "transformer(dm.freesolv()[\"smiles\"][:10]).shape\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(info.usage())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36413f67e3084ac28924eeaf64558e88",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0.00/882 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "46e8469db847407ab4cb17803b2fd5a3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0.00/509k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "torch.Size([10, 32])"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# let's execute the test example and check\n",
-    "transformer = MyAstroChemFeaturizer(dtype=torch.float)\n",
-    "transformer(dm.freesolv()[\"smiles\"][:10]).shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# a bit of cleaning\n",
-    "temp_dir.cleanup()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! rm -rf .env"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can now create a private `modelstore` to save, index and share your custom models."
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+    "nbformat": 4,
+    "nbformat_minor": 0
 }

--- a/env.yml
+++ b/env.yml
@@ -46,6 +46,7 @@ dependencies:
   - sentencepiece
   - biotite # required for ESM model
   - pytorch_geometric >=2.4.0
+  - bio-embeddings[all]
 
   # Optional: viz
   - nglview

--- a/molfeat/store/modelstore.py
+++ b/molfeat/store/modelstore.py
@@ -36,7 +36,7 @@ class ModelStore:
         * Only a single store is supported per model store instance
 
     !!! note "Building a New Model Store"
-        To create a new model store, you will mainly need a model store bucket path. The default model store bucket, located at `gs://molfeat-store-prod/artifacts/`, is **read-only**.
+        To create a new model store, you will mainly need a model store bucket path. The default model store bucket, located at `https://fs.molfeat.datamol.io/artifacts/`, is **read-only**.
 
         To build your own model store bucket, follow the instructions below:
 

--- a/molfeat/trans/pretrained/graphormer.py
+++ b/molfeat/trans/pretrained/graphormer.py
@@ -12,8 +12,17 @@ from molfeat.utils.pooler import Pooling
 from molfeat.trans.pretrained.base import PretrainedMolTransformer
 
 if requires.check("graphormer_pretrained"):
+
+    import graphormer_pretrained
     from graphormer_pretrained.embeddings import GraphormerEmbeddingsExtractor
     from graphormer_pretrained.data.smiles_dataset import GraphormerInferenceDataset
+    graphormer_pretrained.utils.loader.PRETRAINED_MODEL_URLS = {
+    "pcqm4mv1_graphormer_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv1/checkpoint_best_pcqm4mv1.pt",
+    "pcqm4mv2_graphormer_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv2/checkpoint_best_pcqm4mv2.pt",
+    "oc20is2re_graphormer3d_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/oc20is2re/checkpoint_last_oc20_is2re.pt",
+    "pcqm4mv1_graphormer_base_for_molhiv": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv1/checkpoint_base_preln_pcqm4mv1_for_hiv.pt",
+    }
+
 
 
 class GraphormerTransformer(PretrainedMolTransformer):

--- a/molfeat/trans/pretrained/graphormer.py
+++ b/molfeat/trans/pretrained/graphormer.py
@@ -16,13 +16,13 @@ if requires.check("graphormer_pretrained"):
     import graphormer_pretrained
     from graphormer_pretrained.embeddings import GraphormerEmbeddingsExtractor
     from graphormer_pretrained.data.smiles_dataset import GraphormerInferenceDataset
-    graphormer_pretrained.utils.loader.PRETRAINED_MODEL_URLS = {
-    "pcqm4mv1_graphormer_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv1/checkpoint_best_pcqm4mv1.pt",
-    "pcqm4mv2_graphormer_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv2/checkpoint_best_pcqm4mv2.pt",
-    "oc20is2re_graphormer3d_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/oc20is2re/checkpoint_last_oc20_is2re.pt",
-    "pcqm4mv1_graphormer_base_for_molhiv": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv1/checkpoint_base_preln_pcqm4mv1_for_hiv.pt",
-    }
 
+    graphormer_pretrained.utils.loader.PRETRAINED_MODEL_URLS = {
+        "pcqm4mv1_graphormer_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv1/checkpoint_best_pcqm4mv1.pt",
+        "pcqm4mv2_graphormer_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv2/checkpoint_best_pcqm4mv2.pt",
+        "oc20is2re_graphormer3d_base": "https://fs.molfeat.datamol.io/checkpoints/graphormer/oc20is2re/checkpoint_last_oc20_is2re.pt",
+        "pcqm4mv1_graphormer_base_for_molhiv": "https://fs.molfeat.datamol.io/checkpoints/graphormer/pcqm4mv1/checkpoint_base_preln_pcqm4mv1_for_hiv.pt",
+    }
 
 
 class GraphormerTransformer(PretrainedMolTransformer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 authors = [{ name = "Emmanuel Noutahi", email = "emmanuel.noutahi@hotmail.ca" }]
 readme = "README.md"
 license = { text = "Apache" }
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.11"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -68,6 +68,8 @@ viz = ["nglview", "ipywidgets"]
 
 pyg = ["torch_geometric >=2.4.0"]
 
+bioembeddings = [ "bio-embeddings[all]" ]
+
 all = [
     "dgl",
     "dgllife",
@@ -77,7 +79,8 @@ all = [
     "fcd_torch",
     "nglview",
     "ipywidgets",
-    "torch_geometric >=2.4.0"
+    "torch_geometric >=2.4.0",
+    "bioembeddings"
 ]
 
 test = ["pytest >=6.0","pytest-dotenv", "pytest-cov", "pytest-xdist", "black >=22", "ruff"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 authors = [{ name = "Emmanuel Noutahi", email = "emmanuel.noutahi@hotmail.ca" }]
 readme = "README.md"
 license = { text = "Apache" }
-# requires-python = ">=3.9,<3.11"
+requires-python = ">=3.9,<3.14"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 authors = [{ name = "Emmanuel Noutahi", email = "emmanuel.noutahi@hotmail.ca" }]
 readme = "README.md"
 license = { text = "Apache" }
-requires-python = ">=3.9,<3.11"
+# requires-python = ">=3.9,<3.11"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -95,8 +95,8 @@ include-package-data = true
 zip-safe = false
 license-files = ["LICENSE"]
 
-[tool.setuptools_scm]
-fallback_version = "dev"
+# [tool.setuptools_scm]
+# fallback_version = "dev"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ all = [
     "bioembeddings"
 ]
 
-test = ["pytest >=6.0","pytest-dotenv", "pytest-cov", "pytest-xdist", "black >=22", "ruff"]
+test = ["pytest >=6.0","pytest-dotenv", "pytest-cov", "pytest-xdist", "black[jupyter] >=22", "ruff"]
 docs = ["mkdocs", "mike", "mdx_truly_sane_lists", "mkdocs-material >=7.1.1", "mkdocs-jupyter >=0.24.8", "mkdocstrings", "mkdocstrings-python", "markdown-include"]
 dev = ["molfeat[test]", "molfeat[all]", "molfeat[docs]", "pre-commit"]
 


### PR DESCRIPTION
I noticed Github actions have been failing at the setup phase for a few months, and made a few fixes to at least recover proper functioning of the workflows.

## Changelogs

Actions fixes:
 - install black[jupyter] in code-check
 - remove fallback version dev (which is not a tag and probably the source of failure for the tests setup so far)
 - added bioembeddings as an option for pip install (some pytests were failing and asking for it)
 - hardcoded new cloudflare links for graphormer-pretrained (still looking for gs:// URLs)
 - changed the gs:// URLs that were left in comments and notebooks

This leaves a few failures in pytest, but at least they are visible now
